### PR TITLE
add npm package.json and index.js to publish relevant object factories

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+var accessory_Factor           = new require("./Accessory.js");
+var accessoryController_Factor = new require("./AccessoryController.js");
+var service_Factor             = new require("./Service.js");
+var characteristic_Factor      = new require("./Characteristic.js");
+var bridge_Factor              = new require("./BridgedAccessoryController.js");
+var types                      = new require("./accessories/types.js");
+
+var exports = module.exports = {};
+exports.accessoryFactory           = accessory_Factor;
+exports.accessoryControllerFactory = accessoryController_Factor;
+exports.serviceFactory             = service_Factor;
+exports.characteristicFactory      = characteristic_Factor;
+exports.bridgeFactory              = bridge_Factor;
+exports.types                      = types;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "HAP-NodeJS",
+  "version": "0.0.1",
+  "description": "HAP-NodeJS ============= HAP-NodeJS is a Node.js implementation of HomeKit Accessory Server.",
+  "main": "index.js",
+  "dependencies": {
+    "curve25519": "^1.0.0",
+    "ed25519": "^0.0.2",
+    "mdns": "^2.2.0",
+    "atmosphere": "^0.0.2",
+    "atmosphere-client": "^2.2.7",
+    "node-hkdf": "^0.0.1",
+    "node-persist": "^0.0.2",
+    "srp": "^0.2.0",
+    "request": "^2.54.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/htreu/HAP-NodeJS.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/htreu/HAP-NodeJS/issues"
+  },
+  "homepage": "https://github.com/htreu/HAP-NodeJS"
+}


### PR DESCRIPTION
With this commit the HAP-NodeJS can be used as a module to other (bridge) implementations. The object factories are exposed in the index.js. package.json defines current dependencies.