### PR TITLE
Async onRead

### DIFF
--- a/AccessoryController.js
+++ b/AccessoryController.js
@@ -43,19 +43,20 @@ AccessoryController.prototype = {
 		}
 		return JSON.stringify(dict);
 	},
-	jsonForCharacteristicUpdate: function jsonForCharacteristicUpdate(aid, iid) {
+	jsonForCharacteristicUpdate: function jsonForCharacteristicUpdate(aid, iid, callback) {
 		var charObject = this.objects[iid];
-		var charValue = charObject.valueForUpdate();
-		var respDict = {
-			characteristics: [
-				{
-					aid: aid,
-					iid: iid,
-					value: charValue
-				}
-			]
-		}
-		return JSON.stringify(respDict);
+		var charValue = charObject.valueForUpdate(function(value){
+			var respDict = {
+				characteristics: [
+					{
+						aid: aid,
+						iid: iid,
+						value: value
+					}
+				]
+			}
+			callback(JSON.stringify(respDict));
+		});
 	},
 	processSingleCharacteristicsValueWrite: function processSingleCharacteristicsValueWrite(update, peer) {
 		var update_char = update;

--- a/BridgedAccessoryController.js
+++ b/BridgedAccessoryController.js
@@ -17,9 +17,11 @@ BridgedAccessoryController.prototype = {
 		}
 		return JSON.stringify(dict);
 	},
-	jsonForCharacteristicUpdate: function jsonForCharacteristicUpdate(aid, iid) {
+	jsonForCharacteristicUpdate: function jsonForCharacteristicUpdate(aid, iid, callback) {
 		var accessory = this.accessories[aid - 1];
-		return accessory.jsonForCharacteristicUpdate(aid,iid);
+		accessory.jsonForCharacteristicUpdate(aid,iid, function(json){
+			callback(json);
+		});
 	},
 	processCharacteristicsValueWrite: function processCharacteristicsValueWrite(updates, peer) {
 		var updates_objects = JSON.parse(updates.toString());

--- a/BridgedCore.js
+++ b/BridgedCore.js
@@ -56,7 +56,7 @@ for (var i = 0; i < accessoriesJSON.length; i++) {
 		//loop through characteristics
 		for (var k = 0; k < accessoriesJSON[i].services[j].characteristics.length; k++) {
 			var options = {
-				type: accessoriesJSON[i].services[j].characteristics[k].onRead,
+				onRead: accessoriesJSON[i].services[j].characteristics[k].onRead,
 				type: accessoriesJSON[i].services[j].characteristics[k].cType,
 				perms: accessoriesJSON[i].services[j].characteristics[k].perms,
 				format: accessoriesJSON[i].services[j].characteristics[k].format,

--- a/BridgedCore.js
+++ b/BridgedCore.js
@@ -56,6 +56,7 @@ for (var i = 0; i < accessoriesJSON.length; i++) {
 		//loop through characteristics
 		for (var k = 0; k < accessoriesJSON[i].services[j].characteristics.length; k++) {
 			var options = {
+				type: accessoriesJSON[i].services[j].characteristics[k].onRead,
 				type: accessoriesJSON[i].services[j].characteristics[k].cType,
 				perms: accessoriesJSON[i].services[j].characteristics[k].perms,
 				format: accessoriesJSON[i].services[j].characteristics[k].format,

--- a/Characteristic.js
+++ b/Characteristic.js
@@ -128,15 +128,19 @@ Characteristic.prototype = {
 			}
 		} else { console.log("Characteristics.js:updateValue():NotEventEnabled"); }
 	},
-	valueForUpdate: function valueForUpdate() { // reading values FROM THE DEVICE, better: from this object
+	valueForUpdate: function valueForUpdate(callback) { // reading values FROM THE DEVICE, better: from this object
 		console.log("Characteristics.js:valueForUpdate(): called, Siri has asked for the accessory's status");
+
 		if (this.onRead) {
 			console.log("Characteristics.js:valueForUpdate(): invoking callback");
-			var temp = this.onRead();
-			this.value = temp ? temp : this.value;
+			this.onRead(function(value){
+				this.value = value;
+				console.log("Characteristics.js:valueForUpdate(): called, Siri has asked for the accessory's status: returning " + this.value);
+				callback(this.value);
+			});
+		}else{
+			callback(this.value);
 		}
-		console.log("Characteristics.js:valueForUpdate(): called, Siri has asked for the accessory's status: returning " + this.value);
-		return this.value;
 		//
 		
 	}

--- a/Core.js
+++ b/Core.js
@@ -58,6 +58,7 @@ for (var i = 0; i < accessoriesJSON.length; i++) {
 		//loop through characteristics
 		for (var k = 0; k < accessoriesJSON[i].services[j].characteristics.length; k++) {
 			var options = {
+				onRead: accessoriesJSON[i].services[j].characteristics[k].onRead,
 				type: accessoriesJSON[i].services[j].characteristics[k].cType,
 				perms: accessoriesJSON[i].services[j].characteristics[k].perms,
 				format: accessoriesJSON[i].services[j].characteristics[k].format,

--- a/Server.js
+++ b/Server.js
@@ -106,8 +106,12 @@ HAPServer.prototype = {
 			var iids = requestDetails.query.substring(3).split(".");
 			var accessoryId = parseInt(iids[0]);
 			var characteristicId = parseInt(iids[1]);
-			response.write(this.accessoryController.jsonForCharacteristicUpdate(accessoryId,characteristicId));
-			response.end();
+
+			this.accessoryController.jsonForCharacteristicUpdate(accessoryId,characteristicId, function(json){
+				response.write(json);
+				response.end();
+			})
+
 		} else if (request.method == "PUT") {
 			response.writeHead(204, {"Content-Type": "application/hap+json"});
 			this.accessoryController.processCharacteristicsValueWrite(data, request.socket.remotePort);

--- a/accessories/GarageDoorOpener_accessory.js
+++ b/accessories/GarageDoorOpener_accessory.js
@@ -81,10 +81,10 @@ exports.accessory = {
     		console.log("Change:",value); 
     		execute("Garage Door - current door state", "Current State", value); 
     	},
-    	onRead: function() { 
-    		console.log("Read:"); 
+    	onRead: function(callback) {
+    		console.log("Read:");
     		execute("Garage Door - current door state", "Current State", null);
-    		return undefined; // only testing, we have no physical device to read from
+    		callback(undefined); // only testing, we have no physical device to read from
     	},
     	perms: ["pr","ev"],
 		format: "int",
@@ -102,10 +102,10 @@ exports.accessory = {
     		console.log("Change:",value); 
     		execute("Garage Door - target door state", "Current State", value); 
     	},
-    	onRead: function() { 
-    		console.log("Read:"); 
+    	onRead: function(callback) {
+    		console.log("Read:");
     		execute("Garage Door - target door state", "Current State", null);
-    		return undefined; // only testing, we have no physical device to read from
+    		callback(undefined); // only testing, we have no physical device to read from
     	},
     	perms: ["pr","pw","ev"],
 		format: "int",
@@ -123,10 +123,10 @@ exports.accessory = {
     		console.log("Change:",value); 
     		execute("Garage Door - obstruction detected", "Current State", value); 
     	},
-    	onRead: function() { 
-    		console.log("Read:"); 
+    	onRead: function(callback) {
+    		console.log("Read:");
     		execute("Garage Door - obstruction detected", "Current State", null);
-    		return undefined; // only testing, we have no physical device to read from
+    		callback(undefined); // only testing, we have no physical device to read from
     	},
     	perms: ["pr","ev"],
 		format: "bool",


### PR DESCRIPTION
:construction: :construction:  Don't merge yet. Needs discussion :construction: :construction: 

Ok, this is try number 2 to get async state checks for accessories. These are fresh commits since the last ones were actually merged, but then reverted.

## The Goal

This adds callbacks to the `onRead` function, so that we can have asynchronous calls to fetch the state of accessories. HAP-NodeJS might not be the only pace that accessories/devices will be controlled from. So this means HAP-NodeJS won't always have the actual current state. 

Because of this, we need to somehow fetch the current state of an accessory. To do this, we'll need to use callbacks to return the values when we've fetched them. That's what this pull enables.

[According to some research](https://github.com/nfarina/homebridge/issues/6#issuecomment-115495434) by @nfarina, Siri times out at 10 seconds. This should not only be more than enough time to fetch state and return it, but it proves that HomeKit is prepared to wait for this answer. So I think this is more than fine to do this way.

## Difference in Last Attempt

### No Hack to Handle nil `onRead`
This time around, there's no check to make sure `onRead` is ready to be read. `onRead` is properly wired up in the initializer in `Core.js` and `BridgedCore.js`. So the first call to `valueForUpdate` won't fail. So we don't need to handle that weird issue (thank god, that code was embarassin : )

### Bridged Accessories

These callbacks are supported in Bridged Accessories now.

### Handle nil `onRead` Case

It is now handling the case where onRead hasn't been configured by an accessory.

### Notes

Ok, a lot has been said on this topic in the last couple of days, across a lot of threads, heh. Let's try to start over with this pull and keep the discussion in a single place. Thanks for everyone's :eyes:s on this! Please let me know anything  you see that is a problem or would make this better.

/cc @KhaosT @snowdd1 @nfarina