### PR TITLE
Fix onRead, make async

### DIFF
--- a/AccessoryController.js
+++ b/AccessoryController.js
@@ -43,19 +43,20 @@ AccessoryController.prototype = {
 		}
 		return JSON.stringify(dict);
 	},
-	jsonForCharacteristicUpdate: function jsonForCharacteristicUpdate(aid, iid) {
+	jsonForCharacteristicUpdate: function jsonForCharacteristicUpdate(aid, iid, callback) {
 		var charObject = this.objects[iid];
-		var charValue = charObject.valueForUpdate();
-		var respDict = {
-			characteristics: [
-				{
-					aid: aid,
-					iid: iid,
-					value: charValue
-				}
-			]
-		}
-		return JSON.stringify(respDict);
+		var charValue = charObject.valueForUpdate(function(value){
+			var respDict = {
+				characteristics: [
+					{
+						aid: aid,
+						iid: iid,
+						value: value
+					}
+				]
+			}
+			callback(JSON.stringify(respDict));
+		});
 	},
 	processSingleCharacteristicsValueWrite: function processSingleCharacteristicsValueWrite(update, peer) {
 		var update_char = update;

--- a/BridgedAccessoryController.js
+++ b/BridgedAccessoryController.js
@@ -17,9 +17,11 @@ BridgedAccessoryController.prototype = {
 		}
 		return JSON.stringify(dict);
 	},
-	jsonForCharacteristicUpdate: function jsonForCharacteristicUpdate(aid, iid) {
+	jsonForCharacteristicUpdate: function jsonForCharacteristicUpdate(aid, iid, callback) {
 		var accessory = this.accessories[aid - 1];
-		return accessory.jsonForCharacteristicUpdate(aid,iid);
+		accessory.jsonForCharacteristicUpdate(aid,iid, function(json){
+			callback(json);
+		});
 	},
 	processCharacteristicsValueWrite: function processCharacteristicsValueWrite(updates, peer) {
 		var updates_objects = JSON.parse(updates.toString());

--- a/BridgedCore.js
+++ b/BridgedCore.js
@@ -69,6 +69,7 @@ for (var i = 0; i < accessoriesJSON.length; i++) {
 				designedMinStep: accessoriesJSON[i].services[j].characteristics[k].designedMinStep,
 				unit: accessoriesJSON[i].services[j].characteristics[k].unit,
 				onRegister: accessoriesJSON[i].services[j].characteristics[k].onRegister,  // snowdd1
+				onRead: accessoriesJSON[i].services[j].characteristics[k].onRead,  // snowdd1
 				locals: accessoriesJSON[i].locals //snowdd1
 			};
 

--- a/Characteristic.js
+++ b/Characteristic.js
@@ -35,8 +35,9 @@ function Characteristic(options, onUpdate) {
 
 	this.onUpdate = onUpdate;
 	this.onRegister = options.onRegister;
+	this.onRead = options.onRead; // snowdd1 20150513
 	this.locals = options.locals; // local attributes for device control methods // snowdd1
-	
+
 	// new: call onRegister function if one is supplied in the *_accessory file
 	// snowdd1
 	if (options.onRegister) {
@@ -49,13 +50,6 @@ function Characteristic(options, onUpdate) {
 		}
 	}
 	// /snowdd1	 
-	
-	// snowdd1 20150513
-	this.onRead = options.onRead;
-	// /snowdd1 20150513
-	
-	
-	
 }
 
 Characteristic.prototype = {
@@ -128,17 +122,18 @@ Characteristic.prototype = {
 			}
 		} else { console.log("Characteristics.js:updateValue():NotEventEnabled"); }
 	},
-	valueForUpdate: function valueForUpdate() { // reading values FROM THE DEVICE, better: from this object
+	valueForUpdate: function valueForUpdate(callback) { // reading values FROM THE DEVICE, better: from this object
 		console.log("Characteristics.js:valueForUpdate(): called, Siri has asked for the accessory's status");
 		if (this.onRead) {
 			console.log("Characteristics.js:valueForUpdate(): invoking callback");
-			var temp = this.onRead();
-			this.value = temp ? temp : this.value;
+			this.onRead(function(value){
+				this.value = value;
+				console.log("Characteristics.js:valueForUpdate(): called, Siri has asked for the accessory's status: returning " + this.value);
+				callback(this.value);
+			});
+		} else {
+			callback(this.value); // if we don't implement onRead, we return the existing value immediately.
 		}
-		console.log("Characteristics.js:valueForUpdate(): called, Siri has asked for the accessory's status: returning " + this.value);
-		return this.value;
-		//
-		
 	}
 };
 

--- a/Core.js
+++ b/Core.js
@@ -71,6 +71,7 @@ for (var i = 0; i < accessoriesJSON.length; i++) {
 				designedMinStep: accessoriesJSON[i].services[j].characteristics[k].designedMinStep,
 				unit: accessoriesJSON[i].services[j].characteristics[k].unit,
 				onRegister: accessoriesJSON[i].services[j].characteristics[k].onRegister,  // snowdd1
+				onRead: accessoriesJSON[i].services[j].characteristics[k].onRead,  // snowdd1
 				locals: accessoriesJSON[i].locals //snowdd1
 			};
 

--- a/Server.js
+++ b/Server.js
@@ -106,8 +106,12 @@ HAPServer.prototype = {
 			var iids = requestDetails.query.substring(3).split(".");
 			var accessoryId = parseInt(iids[0]);
 			var characteristicId = parseInt(iids[1]);
-			response.write(this.accessoryController.jsonForCharacteristicUpdate(accessoryId,characteristicId));
-			response.end();
+
+			this.accessoryController.jsonForCharacteristicUpdate(accessoryId,characteristicId, function(json){
+				response.write(json);
+				response.end();
+			})
+
 		} else if (request.method == "PUT") {
 			response.writeHead(204, {"Content-Type": "application/hap+json"});
 			this.accessoryController.processCharacteristicsValueWrite(data, request.socket.remotePort);

--- a/accessories/GarageDoorOpener_accessory.js
+++ b/accessories/GarageDoorOpener_accessory.js
@@ -81,10 +81,10 @@ exports.accessory = {
     		console.log("Change:",value); 
     		execute("Garage Door - current door state", "Current State", value); 
     	},
-    	onRead: function() { 
+    	onRead: function(callback) { 
     		console.log("Read:"); 
     		execute("Garage Door - current door state", "Current State", null);
-    		return undefined; // only testing, we have no physical device to read from
+    		callback(undefined); // only testing, we have no physical device to read from
     	},
     	perms: ["pr","ev"],
 		format: "int",
@@ -102,10 +102,10 @@ exports.accessory = {
     		console.log("Change:",value); 
     		execute("Garage Door - target door state", "Current State", value); 
     	},
-    	onRead: function() { 
+    	onRead: function(callback) { 
     		console.log("Read:"); 
     		execute("Garage Door - target door state", "Current State", null);
-    		return undefined; // only testing, we have no physical device to read from
+				callback(undefined); // only testing, we have no physical device to read from
     	},
     	perms: ["pr","pw","ev"],
 		format: "int",
@@ -123,10 +123,10 @@ exports.accessory = {
     		console.log("Change:",value); 
     		execute("Garage Door - obstruction detected", "Current State", value); 
     	},
-    	onRead: function() { 
+    	onRead: function(callback) { 
     		console.log("Read:"); 
     		execute("Garage Door - obstruction detected", "Current State", null);
-    		return undefined; // only testing, we have no physical device to read from
+				callback(undefined); // only testing, we have no physical device to read from
     	},
     	perms: ["pr","ev"],
 		format: "bool",


### PR DESCRIPTION
This PR attempts to re-do async support as well as fixing the existing `onRead` support. See other discussions in [HomeBridge #6](https://github.com/nfarina/homebridge/issues/6#issuecomment-115417438) and #82.

I tried to take @maddox's original async branch and simplify it such that the changes to the `HAP-NodeJS` codebase are as minimal as possible, while also including his fix for `BridgedAccessoryController.js`.

I think that in a perfect world all accessories would be able to receive proactive updates about their state, either by pushed local network events from the accessory itself or from webhooks in the cloud. But many existing accessories were simply not designed for HomeKit and implementing realtime updates for the purposes of synchronous state reading is impractical.

HomeKit is asynchronous by nature and Siri has been designed with up to 10 seconds of "patience" for learning about accessory state. So I think it is reasonable to allow accessory implementors to do a little bit of "work" before responding to her. This doesn't work for 100s of lights but it works great for single accessories like Lockitron.

The changes to `HAP-NodeJS` to support async reads are pretty minimal, just passing a couple callbacks along from Server to Characteristic. I think it's pretty straightforward.

In practice, this is working really well for me - I've implemented `onRead` for Lockitron and it's very quick to check state from their API. Siri now properly says "Your door locks are locked."

/cc @maddox, @snowdd1 