### PR TITLE
Improved Accessory identification

### DIFF
--- a/BridgedCore.js
+++ b/BridgedCore.js
@@ -14,6 +14,12 @@ storage.initSync();
 // Start by creating our Bridge which will host all loaded Accessories
 var bridge = new Bridge('Node Bridge', uuid.generate("Node Bridge"));
 
+// Listen for bridge identification event
+bridge.on('identify', function(paired, callback) {
+  console.log("Node Bridge identify");
+  callback(); // success
+});
+
 // Load up all accessories in the /accessories folder
 var dir = path.join(__dirname, "accessories");
 var accessories = accessoryLoader.loadDirectory(dir);

--- a/accessories/Lock_accessory.js
+++ b/accessories/Lock_accessory.js
@@ -39,16 +39,10 @@ lock
   .setCharacteristic(Characteristic.SerialNumber, "A1S2NASF88EW");
 
 // listen for the "identify" event for this Accessory
-lock
-  .getService(Service.AccessoryInformation)
-  .getCharacteristic(Characteristic.Identify)
-  .on('set', function(value, callback) {
-    if (value) {
-      // called when the iOS user wants to identify which Lock this is
-      FAKE_LOCK.identify();
-    }
-    callback();
-  });
+lock.on('identify', function(paired, callback) {
+  FAKE_LOCK.identify();
+  callback(); // success
+});
 
 // Add the actual Door Lock Service and listen for change events from iOS.
 // We can see the complete list of Services and Characteristics in `lib/gen/HomeKitTypes.js`

--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -28,6 +28,14 @@ module.exports = {
  * is required so that the Bridge can provide consistent "Accessory IDs" (aid) and "Instance IDs" (iid) for all
  * Accessories, Services, and Characteristics for iOS clients to reference later.
  *
+ * @event 'identify' => function(paired, callback(err)) { }
+ *        Emitted when an iOS device wishes for this Accessory to identify itself. If `paired` is false, then
+ *        this device is currently browsing for Accessories in the system-provided "Add Accessory" screen. If
+ *        `paired` is true, then this is a device that has already paired with us. Note that if `paired` is true,
+ *        listening for this event is a shortcut for the underlying mechanism of setting the `Identify` Characteristic:
+ *        `getService(Service.AccessoryInformation).getCharacteristic(Characteristic.Identify).on('set', ...)`
+ *        You must call the callback for identification to be successful.
+ *
  * @event 'service-characteristic-change' => function({service, characteristic, oldValue, newValue, context}) { }
  *        Emitted after a change in the value of one of the provided Service's Characteristics.
  */
@@ -52,6 +60,18 @@ function Accessory(displayName, UUID) {
     .setCharacteristic(Characteristic.Manufacturer, "Default-Manufacturer")
     .setCharacteristic(Characteristic.Model, "Default-Model")
     .setCharacteristic(Characteristic.SerialNumber, "Default-SerialNumber");
+  
+  // sign up for when iOS attempts to "set" the Identify characteristic - this means a paired device wishes
+  // for us to identify ourselves (as opposed to an unpaired device - that case is handled by HAPServer 'identify' event)
+  this
+    .getService(Service.AccessoryInformation)
+    .getCharacteristic(Characteristic.Identify)
+    .on('set', function(value, callback) {
+      if (value) {
+        var paired = true;
+        this._identificationRequest(paired, callback);
+      }
+    }.bind(this));
 }
 
 inherits(Accessory, EventEmitter);
@@ -72,6 +92,20 @@ Accessory.Categories = {
   WINDOW: 13,
   WINDOW_COVERING: 14,
   PROGRAMMABLE_SWITCH: 15
+}
+
+Accessory.prototype._identificationRequest = function(paired, callback) {
+  debug("[%s] Identification request", this.displayName);
+  
+  if (this.listeners('identify').length > 0) {
+    // allow implementors to identify this Accessory in whatever way is appropriate, and pass along
+    // the standard callback for completion.
+    this.emit('identify', paired, callback);
+  }
+  else {
+    debug("[%s] Identification request ignored; no listeners to 'identify' event", this.displayName);
+    callback();
+  }
 }
 
 Accessory.prototype.addService = function(service) {
@@ -299,6 +333,7 @@ Accessory.prototype.publish = function(info) {
   // create our HAP server which handles all communication between iOS devices and us
   this._server = new HAPServer(this._accessoryInfo);
   this._server.on('listening', this._onListening.bind(this));
+  this._server.on('identify', this._handleIdentify.bind(this));
   this._server.on('pair', this._handlePair.bind(this));
   this._server.on('unpair', this._handleUnpair.bind(this));
   this._server.on('accessories', this._handleAccessories.bind(this));
@@ -310,6 +345,12 @@ Accessory.prototype.publish = function(info) {
 Accessory.prototype._onListening = function() {
   // the HAP server is listening, so we can now start advertising our presence.
   this._advertiser.startAdvertising();
+}
+
+// Called when an unpaired client wishes for us to identify ourself
+Accessory.prototype._handleIdentify = function(callback) {
+  var paired = false;
+  this._identificationRequest(paired, callback);
 }
 
 // Called when HAPServer has completed the pairing process with a client

--- a/lib/HAPServer.js
+++ b/lib/HAPServer.js
@@ -39,6 +39,10 @@ module.exports = {
  * @event 'listening' => function() { }
  *        Emitted when the server is fully set up and ready to receive connections.
  *
+ * @event 'identify' => function(callback(err)) { }
+ *        Emitted when a client wishes for this server to identify itself before pairing. You must call the
+ *        callback to respond to the client with success.
+ *
  * @event 'pair' => function(username, publicKey, callback(err)) { }
  *        This event is emitted when a client completes the "pairing" process and exchanges encryption keys.
  *        Note that this does not mean the "Add Accessory" process in iOS has completed. You must call the
@@ -95,6 +99,7 @@ function HAPServer(accessoryInfo, accessoryController) {
 inherits(HAPServer, EventEmitter);
 
 HAPServer.handlers = {
+  '/identify': '_handleIdentify',
   '/pair-setup': '_handlePair',
   '/pair-verify': '_handlePairVerify',
   '/pairings': '_handlePairings',
@@ -198,6 +203,28 @@ HAPServer.prototype._onDecrypt = function(data, decrypted, session) {
   if (enc && enc.controllerToAccessoryKey.length > 0) {
     decrypted.data = encryption.layerDecrypt(data, enc.controllerToAccessoryCount, enc.controllerToAccessoryKey);
   }
+}
+
+/**
+ * Unpaired Accessory identification.
+ */
+
+HAPServer.prototype._handleIdentify = function(request, response, session, events, requestData) {
+  
+  this.emit('identify', function(err) {
+    
+    if (!err) {
+      debug("[%s] Identification success", this.accessoryInfo.username);
+      response.writeHead(204);
+      response.end();
+    }
+    else {
+      debug("[%s] Identification error: %s", this.accessoryInfo.username, err.message);
+      response.writeHead(500);
+      response.end();
+    }
+  
+  }.bind(this));
 }
 
 /**


### PR DESCRIPTION
- Restore ability to identify unpaired Accessories during browsing
- Simplify Accessory identification with new unified 'identify' event
- Example usage in `Lock_accessory.js`