### PR TITLE
Protect certain callbacks against multiple calls

### DIFF
--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -1,5 +1,6 @@
 var inherits = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
+var once = require('./util/once').once;
 
 'use strict';
 
@@ -89,7 +90,7 @@ Characteristic.prototype.getValue = function(callback, context) {
   if (this.listeners('get').length > 0) {
     
     // allow a listener to handle the fetching of this value, and wait for completion
-    this.emit('get', function(err, newValue) {
+    this.emit('get', once(function(err, newValue) {
       
       if (err) {
         // pass the error along to our callback
@@ -106,7 +107,7 @@ Characteristic.prototype.getValue = function(callback, context) {
           this.emit('change', { oldValue:oldValue, newValue:newValue, context:context });
       }
     
-    }.bind(this), context);
+    }.bind(this)), context);
   }
   else {
     
@@ -121,7 +122,7 @@ Characteristic.prototype.setValue = function(newValue, callback, context) {
   if (this.listeners('set').length > 0) {
     
     // allow a listener to handle the setting of this value, and wait for completion
-    this.emit('set', newValue, function(err, changedNewValue) {
+    this.emit('set', newValue, once(function(err, changedNewValue) {
       
       if (err) {
         // pass the error along to our callback
@@ -141,7 +142,7 @@ Characteristic.prototype.setValue = function(newValue, callback, context) {
           this.emit('change', { oldValue:oldValue, newValue:actualNewValue, context:context });
       }
     
-    }.bind(this), context);
+    }.bind(this)), context);
     
   }
   else {

--- a/lib/HAPServer.js
+++ b/lib/HAPServer.js
@@ -9,6 +9,7 @@ var tlv = require("./util/tlv");
 var encryption = require("./util/encryption")
 var EventEmitter = require('events').EventEmitter;
 var EventedHTTPServer = require("./util/eventedhttp").EventedHTTPServer;
+var once = require('./util/once').once;
 
 'use strict';
 
@@ -211,7 +212,7 @@ HAPServer.prototype._onDecrypt = function(data, decrypted, session) {
 
 HAPServer.prototype._handleIdentify = function(request, response, session, events, requestData) {
   
-  this.emit('identify', function(err) {
+  this.emit('identify', once(function(err) {
     
     if (!err) {
       debug("[%s] Identification success", this.accessoryInfo.username);
@@ -224,7 +225,7 @@ HAPServer.prototype._handleIdentify = function(request, response, session, event
       response.end();
     }
   
-  }.bind(this));
+  }.bind(this)));
 }
 
 /**
@@ -396,7 +397,7 @@ HAPServer.prototype._handlePairStepFive = function(request, response, session, c
   encryption.encryptAndSeal(hkdfEncKey, Buffer("PS-Msg06"), message, null, ciphertextBuffer, macBuffer);
 
   // finally, notify listeners that we have been paired with a client
-  this.emit('pair', clientUsername.toString(), clientLTPK, function(err) {
+  this.emit('pair', clientUsername.toString(), clientLTPK, once(function(err) {
 
     if (err) {
       debug("[%s] Error adding pairing info: %s", this.accessoryInfo.username, err.message);
@@ -411,7 +412,7 @@ HAPServer.prototype._handlePairStepFive = function(request, response, session, c
       HAPServer.Types.SEQUENCE_NUM, 0x06,
       HAPServer.Types.ENCRYPTED_DATA, Buffer.concat([ciphertextBuffer,macBuffer])
     ));
-  });
+  }));
 }
 
 /**
@@ -578,7 +579,7 @@ HAPServer.prototype._handlePairings = function(request, response, session, event
     var clientUsername = objects[HAPServer.Types.USERNAME];
     var clientLTPK = objects[HAPServer.Types.PUBLIC_KEY];
     
-    this.emit('pair', clientUsername.toString(), clientLTPK, function(err) {
+    this.emit('pair', clientUsername.toString(), clientLTPK, once(function(err) {
 
       if (err) {
         debug("[%s] Error adding pairing info: %s", this.accessoryInfo.username, err.message);
@@ -590,14 +591,14 @@ HAPServer.prototype._handlePairings = function(request, response, session, event
       response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
       response.end(tlv.encode(HAPServer.Types.SEQUENCE_NUM, 0x02));
 
-    }.bind(this));
+    }.bind(this)));
   }
   else if (requestType == 4) {
     
     debug("[%s] Removing pairing info for client", this.accessoryInfo.username);
     var clientUsername = objects[HAPServer.Types.USERNAME];
 
-    this.emit('unpair', clientUsername.toString(), function(err) {
+    this.emit('unpair', clientUsername.toString(), once(function(err) {
 
       if (err) {
         debug("[%s] Error removing pairing info: %s", this.accessoryInfo.username, err.message);
@@ -609,7 +610,7 @@ HAPServer.prototype._handlePairings = function(request, response, session, event
       response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
       response.end(tlv.encode(HAPServer.Types.SEQUENCE_NUM, 0x02));
 
-    }.bind(this));
+    }.bind(this)));
   }
 }
 
@@ -622,7 +623,7 @@ HAPServer.prototype._handlePairings = function(request, response, session, event
 HAPServer.prototype._handleAccessories = function(request, response, session, events, requestData) {
 
   // call out to listeners to retrieve the latest accessories JSON
-  this.emit('accessories', function(err, accessories) {
+  this.emit('accessories', once(function(err, accessories) {
     
     if (err) {
       debug("[%s] Error getting accessories: %s", this.accessoryInfo.username, err.message);
@@ -633,7 +634,7 @@ HAPServer.prototype._handleAccessories = function(request, response, session, ev
     
     response.writeHead(200, {"Content-Type": "application/hap+json"});
     response.end(JSON.stringify(accessories));
-  });
+  }));
 }
 
 // Called when the client wishes to get or set particular characteristics
@@ -657,7 +658,7 @@ HAPServer.prototype._handleCharacteristics = function(request, response, session
       var aid = parseInt(req[0]); // accessory ID
       var iid = parseInt(req[1]); // instance ID (for characteristic)
 
-      this.emit('get-characteristic', aid, iid, events, function(err, data) {
+      this.emit('get-characteristic', aid, iid, events, once(function(err, data) {
         responseCount -= 1;
         if (!data && !err)
           err = new Error("data was not supplied by the get-characteristic event callback");
@@ -685,7 +686,7 @@ HAPServer.prototype._handleCharacteristics = function(request, response, session
             characteristics: characteristicResponses
           }));
         };
-      }.bind(this));
+      }.bind(this)));
     }
   }
   else if (request.method == "PUT") {
@@ -694,7 +695,7 @@ HAPServer.prototype._handleCharacteristics = function(request, response, session
     var data = JSON.parse(requestData.toString());
     
     // call out to listeners to retrieve the latest accessories JSON
-    this.emit('set-characteristics', data, events, function(err) {
+    this.emit('set-characteristics', data, events, once(function(err) {
       
       if (err) {
         debug("[%s] Error setting characteristics: %s", this.accessoryInfo.username, err.message);
@@ -705,7 +706,7 @@ HAPServer.prototype._handleCharacteristics = function(request, response, session
       
       response.writeHead(204, {"Content-Type": "application/hap+json"});
       response.end();
-    }.bind(this));
+    }.bind(this)));
   }
 }
 

--- a/lib/util/once.js
+++ b/lib/util/once.js
@@ -1,0 +1,18 @@
+
+module.exports = {
+  once: once
+}
+
+function once(func) {
+  var called = false;
+  
+  return function() {
+    if (called) {
+      throw new Error("This callback function has already been called by someone else; it can only be called one time.");
+    }
+    else {
+      called = true;
+      return func.apply(this, arguments);
+    }
+  }
+}


### PR DESCRIPTION
Especially for Characteristic get/set events, we want to make sure that
calling them twice results in an Error (as this will otherwise cause
unpredictable problems).