### PR TITLE
Handle errors cleanly in get-characteristics

### DIFF
--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -342,7 +342,7 @@ Accessory.prototype.publish = function(info) {
   this._server.on('pair', this._handlePair.bind(this));
   this._server.on('unpair', this._handleUnpair.bind(this));
   this._server.on('accessories', this._handleAccessories.bind(this));
-  this._server.on('get-characteristic', this._handleGetCharacteristic.bind(this));
+  this._server.on('get-characteristics', this._handleGetCharacteristics.bind(this));
   this._server.on('set-characteristics', this._handleSetCharacteristics.bind(this));
   this._server.listen(this._accessoryInfo.port);
 }
@@ -401,46 +401,74 @@ Accessory.prototype._handleAccessories = function(callback) {
   });
 }
 
-// Called when an iOS client wishes to query the state of a particular characteristic, like "door open"? or "light on?"
-Accessory.prototype._handleGetCharacteristic = function(aid, iid, events, callback) {
-
-  var characteristic = this.findCharacteristic(aid, iid);
-
-  if (!characteristic) {
-    callback(new Error("Could not find a Characteristic with iid of " + iid + " and aid of " + aid));
-    return;
-  }
-
-  // Found the Characteristic! Get the value!
-  debug('[%s] Getting value for Characteristic "%s"', this.displayName, characteristic.displayName);
+// Called when an iOS client wishes to query the state of one or more characteristics, like "door open?", "light on?", etc.
+Accessory.prototype._handleGetCharacteristics = function(data, events, callback) {
   
-  // we want to remember "who" made this request, so that we don't send them an event notification
-  // about any changes that occurred as a result of the request. For instance, if after querying
-  // the current value of a characteristic, the value turns out to be different than the previously
-  // cached Characteristic value, an internal 'change' event will be emitted which will cause us to
-  // notify all connected clients about that new value. But this client is about to get the new value
-  // anyway, so we don't want to notify it twice.
-  var context = events;
+  // build up our array of responses to the characteristics requested asynchronously
+  var characteristics = [];
+  
+  data.forEach(function(characteristicData) {
+    var aid = characteristicData.aid;
+    var iid = characteristicData.iid;
 
-  // set the value and wait for success
-  characteristic.getValue(function(err, value) {
-    
-    debug('[%s] Got Characteristic "%s" value: %s', this.displayName, characteristic.displayName, value);
+    var characteristic = this.findCharacteristic(characteristicData.aid, characteristicData.iid);
 
-    if (err) {
-      debug('[%s] Error getting value for Characteristic "%s": %s', this.displayName, characteristic.displayName, err.message);
-      callback(err);
+    if (!characteristic) {
+      debug('[%s] Could not find a Characteristic with iid of %s and aid of %s', this.displayName, characteristicData.aid, characteristicData.iid);
+      characteristics.push({
+        aid: aid,
+        iid: iid,
+        status: -70402 // error status
+      });
+      return;
     }
+
+    // Found the Characteristic! Get the value!
+    debug('[%s] Getting value for Characteristic "%s"', this.displayName, characteristic.displayName);
     
-    // all done - compose the response and send it to the callback
-    callback(null, {
-      aid: aid,
-      iid: iid,
-      value: value,
-      status: 0
-    });
+    // we want to remember "who" made this request, so that we don't send them an event notification
+    // about any changes that occurred as a result of the request. For instance, if after querying
+    // the current value of a characteristic, the value turns out to be different than the previously
+    // cached Characteristic value, an internal 'change' event will be emitted which will cause us to
+    // notify all connected clients about that new value. But this client is about to get the new value
+    // anyway, so we don't want to notify it twice.
+    var context = events;
+
+    // set the value and wait for success
+    characteristic.getValue(function(err, value) {
+      
+      debug('[%s] Got Characteristic "%s" value: %s', this.displayName, characteristic.displayName, value);
+
+      if (err) {
+        debug('[%s] Error getting value for Characteristic "%s": %s', this.displayName, characteristic.displayName, err.message);
+        characteristics.push({
+          aid: aid,
+          iid: iid,
+          status: -70402 // error status
+        });
+      }
+      else {
+        // compose the response and add it to the list
+        characteristics.push({
+          aid: aid,
+          iid: iid,
+          value: value,
+          status: 0
+        });
+      }
+      
+      // have we collected all responses yet?
+      if (characteristics.length === data.length)
+        callback(null, characteristics);
+      
+    }.bind(this), context);    
     
-  }.bind(this), context);
+  }.bind(this));
+  
+  // have we already collected all responses on this first pass? if all characteristics were not found
+  // for instance, this may be the case. so we'll need to call the callback.
+  if (characteristics.length === data.length)
+    callback(null, characteristics);
 }
 
 // Called when an iOS client wishes to change the state of this accessory - like opening a door, or turning on a light.

--- a/lib/HAPServer.js
+++ b/lib/HAPServer.js
@@ -63,10 +63,11 @@ module.exports = {
  *        Accessories in the case of a Bridge Accessory. The listener must call the provided callback function
  *        when the accessory data is ready. We will automatically JSON.stringify the data.
  *
- * @event 'get-characteristic' => function(aid, iid, events, callback(err, data)) { }
- *        This event is emitted when a client wishes to retrieve the current value of a specific characteristic.
- *        The listener must call the provided callback function when the value is ready. iOS clients can typically
- *        wait up to 10 seconds for this call to return. We will automatically JSON.stringify the data.
+ * @event 'get-characteristics' => function(data, events, callback(err, characteristics)) { }
+ *        This event is emitted when a client wishes to retrieve the current value of one or more characteristics.
+ *        The listener must call the provided callback function when the values are ready. iOS clients can typically
+ *        wait up to 10 seconds for this call to return. We will automatically JSON.stringify the data (which must 
+ *        be an array) and wrap it in an object with a top-level "characteristics" property.
  *
  * @event 'set-characteristics' => function(data, events, callback(err)) { }
  *        This event is emitted when a client wishes to set the current value of one or more characteristics and/or
@@ -642,49 +643,35 @@ HAPServer.prototype._handleCharacteristics = function(request, response, session
   
   if (request.method == "GET") {
     
-    // Extract the query params from the URL which looks like: /characteristics?id=1.9
+    // Extract the query params from the URL which looks like: /characteristics?id=1.9,2.14,...
     var parseQueryString = true;
-    var query = url.parse(request.url, parseQueryString).query; // { id: '1.9' }
-    var ids = query.id.split(',');
-
-    var characteristicResponses = [];
-    var responseCount = ids.length;
-    var encounteredError = false;
-
-    for (var idx in ids) {
-      var id = ids[idx];
-      var req = id.split('.');
-
-      var aid = parseInt(req[0]); // accessory ID
-      var iid = parseInt(req[1]); // instance ID (for characteristic)
-
-      this.emit('get-characteristic', aid, iid, events, once(function(err, data) {
-        responseCount -= 1;
-        if (!data && !err)
-          err = new Error("data was not supplied by the get-characteristic event callback");
-
-        if (err) {
-          encounteredError = true;
-          debug("[%s] Error getting characteristic: %s", this.accessoryInfo.username, err.message);
-          characteristicResponses.push({
-            aid: aid,
-            iid: iid,
-            status: -70402
-          });
-        } else {
-          characteristicResponses.push(data);
-        }
-        
-        if (responseCount == 0) {
-          var respCode = 207;
-                    
-          response.writeHead(respCode, {"Content-Type": "application/hap+json"});
-          response.end(JSON.stringify({
-            characteristics: characteristicResponses
-          }));
-        };
-      }.bind(this)));
+    var query = url.parse(request.url, parseQueryString).query; // { id: '1.9,2.14' }
+    var sets = query.id.split(','); // ["1.9","2.14"]
+    var data = []; // [{aid:1,iid:9},{aid:2,iid:14}]
+    
+    for (var i in sets) {
+      var ids = sets[i].split('.'); // ["1","9"]
+      var aid = parseInt(ids[0]); // accessory ID
+      var iid = parseInt(ids[1]); // instance ID (for characteristic)
+      data.push({aid:aid,iid:iid});
     }
+
+    this.emit('get-characteristics', data, events, function(err, characteristics) {
+
+      if (!characteristics && !err)
+        err = new Error("characteristics not supplied by the get-characteristics event callback");
+
+      if (err) {
+        debug("[%s] Error getting characteristics: %s", this.accessoryInfo.username, err.message);
+        response.writeHead(500, "Server Error");
+        response.end();
+        return;
+      }
+      
+      // 207 is "multi-status" since HomeKit is requesting multiple things and any one can fail independently      
+      response.writeHead(207, {"Content-Type": "application/hap+json"});
+      response.end(JSON.stringify({characteristics:characteristics}));
+    }.bind(this));
   }
   else if (request.method == "PUT") {
     


### PR DESCRIPTION
- Move the "get characteristics loop" to Accessory, matching "set
characteristics" design
- Handles properly when get-accessory calls back with an error