### PR TITLE
Get characteristic security enhancements

### DIFF
--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -152,7 +152,7 @@ Accessory.prototype.getService = function(name) {
       return service;
   }
   // failed
-  throw new Error("Accessory.prototype.getService: failed to find service "+ (typeof name === 'string') ? name : name.UUID )
+  throw new Error("Accessory.prototype.getService: failed to find service "+ (typeof name === 'string') ? name : name.UUID );
 }
 
 Accessory.prototype.addBridgedAccessory = function(accessory) {

--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -151,6 +151,8 @@ Accessory.prototype.getService = function(name) {
     else if (typeof name === 'function' && service instanceof name)
       return service;
   }
+  // failed
+  throw new Error("Accessory.prototype.getService: failed to find service "+ (typeof name === 'string') ? name : name.UUID )
 }
 
 Accessory.prototype.addBridgedAccessory = function(accessory) {

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -47,10 +47,10 @@ function Service(displayName, UUID, subtype) {
   // every service has an optional Characteristic.Name property - we'll set it to our displayName
   // if one was given
   if (displayName) {
-    // create the charactersitic if necessary
+    // create the characteristic if necessary
     var nameCharacteristic =
-      this.getCharacteristic(Characteristic.Name) ||
-      this.addCharacteristic(Characteristic.Name);
+      this.getCharacteristic(Characteristic.Name, true) ||
+      this.addCharacteristic(Characteristic.Name, true);
     
     nameCharacteristic.setValue(displayName);
   }
@@ -58,19 +58,19 @@ function Service(displayName, UUID, subtype) {
 
 inherits(Service, EventEmitter);
 
-Service.prototype.addCharacteristic = function(characteristic) {
+Service.prototype.addCharacteristic = function(characteristic, nowarn) {
 	// characteristic might be a constructor like `Characteristic.Brightness` instead of an instance
 	// of Characteristic. Coerce if necessary.
 	var optFound = false;
 	if (typeof characteristic === 'function') {
 		// Look in the optionals for the type
 		for (var index in this.optionalCharacteristics) {
-			var characteristic = this.characteristics[index];
-			if (characteristic instanceof name) {
+			var optcharacteristic = this.characteristics[index];
+			if (optcharacteristic instanceof characteristic) {
 				optFound = true;
 			}
 		}
-		if (!optFound) {
+		if (!optFound && !nowarn) {
 			console.log("WARNING: Service.prototype.addCharacteristic: adding characteristic that is not a know optional type for the service "+this.UUID);
 		}
 		characteristic = new (Function.prototype.bind.apply(characteristic, arguments));
@@ -93,13 +93,14 @@ Service.prototype.addCharacteristic = function(characteristic) {
 	return characteristic;
 }
 
-Service.prototype.getCharacteristic = function(name) {
+Service.prototype.getCharacteristic = function(name, nofail) {
 	// returns a characteristic object from the service
 	//If  Service.prototype.getCharacteristic(Characteristic.Type)  does not find the characteristic, 
 	// 	AND it is no optionalCharacteristic match, it fails ungracefully and throws an error; programmer can use  addCharacteristic()  
 	//	to add it anyhow, but will then receive a WARNING in console log entry.
 	//If  Service.prototype.getCharacteristic(Characteristic.Type)  does not find the characteristic, 
 	//  BUT the type is in optionalCharacteristic, it adds the characteristic.type and returns it.
+	// If nofail is true it will return undefined instead of throwing!
 
 	for (var index in this.characteristics) {
 		var characteristic = this.characteristics[index];
@@ -111,7 +112,7 @@ Service.prototype.getCharacteristic = function(name) {
 		}
 	}
 	// not found yet, look in the optionals
-	if (!foundChar && typeof name === 'function')  {
+	if (typeof name === 'function')  {
 		for (var index in this.optionalCharacteristics) {
 			var characteristic = this.characteristics[index];
 			if (characteristic instanceof name) {
@@ -120,7 +121,11 @@ Service.prototype.getCharacteristic = function(name) {
 		}
 	}
 	// fail with exception if made it to here without a valid match
-	throw new Error("Service.GetCharacteristic(name) failed: no such characteristic - you may add it first")
+	if (!nofail) {
+		throw new Error("Service.GetCharacteristic(name) failed: no such characteristic - you may add it first");
+	} else {
+		return undefined;
+	}
 }
 
 Service.prototype.setCharacteristic = function(name, value) {

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -59,37 +59,68 @@ function Service(displayName, UUID, subtype) {
 inherits(Service, EventEmitter);
 
 Service.prototype.addCharacteristic = function(characteristic) {
-  // characteristic might be a constructor like `Characteristic.Brightness` instead of an instance
-  // of Characteristic. Coerce if necessary.
-  if (typeof characteristic === 'function')
-  characteristic = new (Function.prototype.bind.apply(characteristic, arguments));
+	// characteristic might be a constructor like `Characteristic.Brightness` instead of an instance
+	// of Characteristic. Coerce if necessary.
+	var optFound = false;
+	if (typeof characteristic === 'function') {
+		// Look in the optionals for the type
+		for (var index in this.optionalCharacteristics) {
+			var characteristic = this.characteristics[index];
+			if (characteristic instanceof name) {
+				optFound = true;
+			}
+		}
+		if (!optFound) {
+			console.log("WARNING: Service.prototype.addCharacteristic: adding characteristic that is not a know optional type for the service "+this.UUID);
+		}
+		characteristic = new (Function.prototype.bind.apply(characteristic, arguments));
+	}
 
-  // check for UUID conflict
-  for (var index in this.characteristics) {
-    var existing = this.characteristics[index];
-    if (existing.UUID === characteristic.UUID)
-      throw new Error("Cannot add a Characteristic with the same UUID as another Characteristic in this Service: " + existing.UUID);
-  }
-  
-  // listen for changes in characteristics and bubble them up
-  characteristic.on('change', function(change) {
-    // make a new object with the relevant characteristic added, and bubble it up
-    this.emit('characteristic-change', clone(change, {characteristic:characteristic}));
-  }.bind(this));
+	// check for UUID conflict
+	for (var index in this.characteristics) {
+		var existing = this.characteristics[index];
+		if (existing.UUID === characteristic.UUID)
+			throw new Error("Cannot add a Characteristic with the same UUID as another Characteristic in this Service: " + existing.UUID + ". Duplicate display names used?");
+	}
 
-  this.characteristics.push(characteristic);
-  return characteristic;
+	// listen for changes in characteristics and bubble them up
+	characteristic.on('change', function(change) {
+		// make a new object with the relevant characteristic added, and bubble it up
+		this.emit('characteristic-change', clone(change, {characteristic:characteristic}));
+	}.bind(this));
+
+	this.characteristics.push(characteristic);
+	return characteristic;
 }
 
 Service.prototype.getCharacteristic = function(name) {
-  for (var index in this.characteristics) {
-    var characteristic = this.characteristics[index];
-    
-    if (typeof name === 'string' && characteristic.displayName === name)
-      return characteristic;
-    else if (typeof name === 'function' && characteristic instanceof name)
-      return characteristic;
-  }
+	// returns a characteristic object from the service
+	//If  Service.prototype.getCharacteristic(Characteristic.Type)  does not find the characteristic, 
+	// 	AND it is no optionalCharacteristic match, it fails ungracefully and throws an error; programmer can use  addCharacteristic()  
+	//	to add it anyhow, but will then receive a WARNING in console log entry.
+	//If  Service.prototype.getCharacteristic(Characteristic.Type)  does not find the characteristic, 
+	//  BUT the type is in optionalCharacteristic, it adds the characteristic.type and returns it.
+
+	for (var index in this.characteristics) {
+		var characteristic = this.characteristics[index];
+
+		if (typeof name === 'string' && characteristic.displayName === name) {
+			return characteristic;
+		} else if (typeof name === 'function' && characteristic instanceof name) {
+			return characteristic;
+		}
+	}
+	// not found yet, look in the optionals
+	if (!foundChar && typeof name === 'function')  {
+		for (var index in this.optionalCharacteristics) {
+			var characteristic = this.characteristics[index];
+			if (characteristic instanceof name) {
+				return this.addCharacteristic(name);
+			}
+		}
+	}
+	// fail with exception if made it to here without a valid match
+	throw new Error("Service.GetCharacteristic(name) failed: no such characteristic - you may add it first")
 }
 
 Service.prototype.setCharacteristic = function(name, value) {

--- a/lib/gen/HomeKitTypes.js
+++ b/lib/gen/HomeKitTypes.js
@@ -1253,11 +1253,11 @@ Service.AccessoryInformation = function(displayName, subtype) {
   Service.call(this, displayName, '0000003E-0000-1000-8000-0026BB765291', subtype);
 
   // Required Characteristics
-  this.addCharacteristic(Characteristic.Identify);
-  this.addCharacteristic(Characteristic.Manufacturer);
-  this.addCharacteristic(Characteristic.Model);
-  this.addCharacteristic(Characteristic.Name);
-  this.addCharacteristic(Characteristic.SerialNumber);
+  this.addCharacteristic(Characteristic.Identify, true);
+  this.addCharacteristic(Characteristic.Manufacturer, true);
+  this.addCharacteristic(Characteristic.Model, true);
+  this.addCharacteristic(Characteristic.Name, true);
+  this.addCharacteristic(Characteristic.SerialNumber, true);
 
   // Optional Characteristics
   this.addOptionalCharacteristic(Characteristic.FirmwareRevision);
@@ -1513,7 +1513,7 @@ Service.Lightbulb = function(displayName, subtype) {
   Service.call(this, displayName, '00000043-0000-1000-8000-0026BB765291', subtype);
 
   // Required Characteristics
-  this.addCharacteristic(Characteristic.On);
+  this.addCharacteristic(Characteristic.On, true);
 
   // Optional Characteristics
   this.addOptionalCharacteristic(Characteristic.Brightness);

--- a/lib/gen/import.js
+++ b/lib/gen/import.js
@@ -113,7 +113,7 @@ for (var index in metadata.Services) {
       // look up the classyName from the hash we built above
       var characteristicClassyName = characteristics[characteristicUUID];
       
-      output.write("  this.addCharacteristic(Characteristic." + characteristicClassyName + ");\n");
+      output.write("  this.addCharacteristic(Characteristic." + characteristicClassyName + ", true);\n"); // added "true" to avoid warning message that this is not an optional characteristic
     }
   }
 


### PR DESCRIPTION
As discussed in #121 

Service.getCharacteristic(name, nofail) fails with an exception if name is not an existing or optional Characteristic. If it is an optional, it gets added and returned.
For internal use, nofail will return undefined if not found. Allows for getCharacteristic(Some, true) || addCharacteristic(Some, true).


Service.addCharacteristic(Characteristic.Type, nowarn) issues a warning to console if the characteristic.Type is not found in optionalCharacteristics of the service. nowarn=true suppresses this warning (if you know what you are doing, and of course for initial creation of service types)
