### PR TITLE
Lightweight get-characteristic change

### DIFF
--- a/lib/Service.js
+++ b/lib/Service.js
@@ -61,9 +61,9 @@ inherits(Service, EventEmitter);
 Service.prototype.addCharacteristic = function(characteristic) {
   // characteristic might be a constructor like `Characteristic.Brightness` instead of an instance
   // of Characteristic. Coerce if necessary.
-  if (typeof characteristic === 'function')
-  characteristic = new (Function.prototype.bind.apply(characteristic, arguments));
-
+  if (typeof characteristic === 'function') {
+	  characteristic = new (Function.prototype.bind.apply(characteristic, arguments));
+  }
   // check for UUID conflict
   for (var index in this.characteristics) {
     var existing = this.characteristics[index];
@@ -82,14 +82,42 @@ Service.prototype.addCharacteristic = function(characteristic) {
 }
 
 Service.prototype.getCharacteristic = function(name) {
-  for (var index in this.characteristics) {
-    var characteristic = this.characteristics[index];
-    
-    if (typeof name === 'string' && characteristic.displayName === name)
-      return characteristic;
-    else if (typeof name === 'function' && characteristic instanceof name)
-      return characteristic;
-  }
+	// returns a characteristic object from the service
+	// If  Service.prototype.getCharacteristic(Characteristic.Type)  does not find the characteristic, 
+	// but the type is in optionalCharacteristics, it adds the characteristic.type to the service and returns it.
+	var index, characteristic;
+	for (index in this.characteristics) {
+		characteristic = this.characteristics[index];
+		if (typeof name === 'string' && characteristic.displayName === name) {
+			return characteristic;
+		}
+		else if (typeof name === 'function' && characteristic instanceof name) {
+			return characteristic;
+		}
+	}
+	if (typeof name === 'function')  {
+		for (index in this.optionalCharacteristics) {
+			characteristic = this.characteristics[index];
+			if (characteristic instanceof name) {
+				return this.addCharacteristic(name);
+			}
+		}
+	}
+};
+
+Service.prototype.testCharacteristic = function(name) {
+	// checks for the existence of a characteristic object in the service
+	var index, characteristic;
+	for (index in this.characteristics) {
+		characteristic = this.characteristics[index];
+		if (typeof name === 'string' && characteristic.displayName === name) {
+			return true;
+		}
+		else if (typeof name === 'function' && characteristic instanceof name) {
+			return true;
+		}
+	}
+	return false;
 }
 
 Service.prototype.setCharacteristic = function(name, value) {


### PR DESCRIPTION
Replacement for  #128, tailored for @KhaosT 's wishes, as voiced in https://github.com/KhaosT/HAP-NodeJS/issues/121#issuecomment-139820333

>@snowdd1 Sorry for the confusion, I think having the ability to return a new optional characteristic on get characteristic is the one I want to keep. 

`Service.getCharacteristic(name)` now returns a new Characteristic object if the Characteristic is not yet present, but the name passed is an instance of an optional Characteristic of that service, like `Characteristic.Brightness` for a `Service.Lightbulb`.

To keep a possibility to test for the existence of a Characteristic *without* accidentally adding it I introduced a new separate function `Service.testCharacteristic(name)` which returns a Boolean value.

This PR does not introduce any slightly foul-smelling extra parameters, does not manipulate the generator and is supposed to be a nonbreaking change for existing installations.

Tested with node 4.1.1 and my KNX platform shim, together with PR https://github.com/nfarina/homebridge/pull/233

