### PR TITLE
Save context created by plugins

### DIFF
--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -437,7 +437,7 @@ Accessory.prototype._handleGetCharacteristics = function(data, events, callback)
     // cached Characteristic value, an internal 'change' event will be emitted which will cause us to
     // notify all connected clients about that new value. But this client is about to get the new value
     // anyway, so we don't want to notify it twice.
-    var context = events;
+    var context = null;
 
     // set the value and wait for success
     characteristic.getValue(function(err, value) {
@@ -511,7 +511,7 @@ Accessory.prototype._handleSetCharacteristics = function(data, events, callback)
     // by Characteristic and passed on to the corresponding 'change' events bubbled up from Characteristic
     // through Service and Accessory. We'll assign it to the events object since it essentially represents
     // the connection requesting the change.
-    var context = events;
+    var context = null;
     
     // if "ev" is present, that means we need to register or unregister this client for change events for
     // this characteristic.

--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -46,6 +46,7 @@ function Characteristic(displayName, UUID, props) {
   this.UUID = UUID;
   this.iid = null; // assigned by our containing Service
   this.value = null;
+  this.context;
   this.props = props || {
     format: null,
     unit: null,
@@ -113,6 +114,13 @@ Characteristic.prototype.setProps = function(props) {
 
 Characteristic.prototype.getValue = function(callback, context) {
   
+  if (context) {
+    this.context = context;
+  }
+  else {
+    context = this.context;
+  }
+  
   if (this.listeners('get').length > 0) {
     
     // allow a listener to handle the fetching of this value, and wait for completion
@@ -145,6 +153,13 @@ Characteristic.prototype.getValue = function(callback, context) {
 
 Characteristic.prototype.setValue = function(newValue, callback, context) {
 
+  if (context) {
+    this.context = context;
+  }
+  else {
+    context = this.context;
+  }
+  
   if (this.listeners('set').length > 0) {
     
     // allow a listener to handle the setting of this value, and wait for completion


### PR DESCRIPTION
As far as I know context was originally introduced in order to be able
to save plugins (shims) properties like who did trigger "setValue()".
This modification prevents that context is overwritten by hap-nodejs.