### PR TITLE
Prevent clearing AccessoryInfo files

### DIFF
--- a/lib/model/AccessoryInfo.js
+++ b/lib/model/AccessoryInfo.js
@@ -114,6 +114,6 @@ AccessoryInfo.prototype.save = function() {
   
   var key = AccessoryInfo.persistKey(this.username);
   
-  storage.setItem(key, saved);
+  storage.setItemSync(key, saved);
   storage.persistSync();
 }

--- a/lib/model/IdentifierCache.js
+++ b/lib/model/IdentifierCache.js
@@ -119,6 +119,6 @@ IdentifierCache.prototype.save = function() {
   
   var key = IdentifierCache.persistKey(this.username);
   
-  storage.setItem(key, saved);
+  storage.setItemSync(key, saved);
   storage.persistSync();
 }


### PR DESCRIPTION
persistSync() should not be called, before seItem() is ready. In my case, AccessoryInfo files were cleared, which caused recreation and ultimately preventing reconnection. Calling synchronous setItemSync() fixes that.