### PR TITLE
added maxLen validation for string characteristics

### DIFF
--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -217,7 +217,6 @@ Characteristic.prototype.toHAP = function(opt) {
     
     // These properties used to be sent but do not seem to be used:
     //
-    // maxLen: this.format === Characteristic.Formats.STRING ? 255 : 1,
     // events: false,
     // bonjour: false
   };
@@ -227,7 +226,19 @@ Characteristic.prototype.toHAP = function(opt) {
   if (this.props.maxValue != null) hap.maxValue = this.props.maxValue;
   if (this.props.minValue != null) hap.minValue = this.props.minValue;
   if (this.props.minStep != null) hap.minStep = this.props.minStep;
-  
+
+  // add maxLen if string length is > 64 bytes and trim to max 256 bytes
+  if (this.props.format === Characteristic.Formats.STRING) {
+    var str = new Buffer(value, 'utf8'),
+        len = str.byteLength;
+    if (len > 256) { // 256 bytes is the max allowed length
+      hap.value = str.toString('utf8', 0, 256);
+      hap.maxLen = 256;
+    } else if (len > 64) { // values below can be ommited
+      hap.maxLen = len;
+    }
+  }
+
   // if we're not readable, omit the "value" property - otherwise iOS will complain about non-compliance
   if (this.props.perms.indexOf(Characteristic.Perms.READ) == -1)
     delete hap.value;


### PR DESCRIPTION
otherwise iOS complains and about half of the accessories won't appear