### PR TITLE
Change deprecated 'licenses' property to 'license'

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,7 @@
     "url": "https://github.com/KhaosT/HAP-NodeJS.git"
   },
   "author": "Khaos Tian <khaos.tian@gmail.com> (http://tz.is/)",
-  "licenses": [
-    {
-      "type": "Apache-2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0"
-    }
-  ],
+  "license":  "Apache-2.0",
   "bugs": {
     "url": "https://github.com/KhaosT/HAP-NodeJS/issues"
   },


### PR DESCRIPTION
'npm install' warns about no license field available in package.json.