### PR TITLE
EventedHTTPServer: Don’t assume high-numbered ports aren’t in use (#131).

### DIFF
--- a/lib/util/eventedhttp.js
+++ b/lib/util/eventedhttp.js
@@ -104,7 +104,6 @@ EventedHTTPServer.prototype._handleConnectionClose = function(connection) {
  
 function EventedHTTPServerConnection(clientSocket) {
   this._remoteAddress = clientSocket.remoteAddress; // cache because it becomes undefined in 'onClientSocketClose'
-  this._httpPort = PortAllocator.allocatePort(); // grab the next open port
   this._pendingClientSocketData = Buffer(0); // data received from client before HTTP proxy is fully setup
   this._fullySetup = false; // true when we are finished establishing connections
   this._writingResponse = false; // true while we are composing an HTTP response (so events can wait)
@@ -122,10 +121,10 @@ function EventedHTTPServerConnection(clientSocket) {
   // create our internal HTTP server for this connection that we will proxy data to and from
   this._httpServer = http.createServer();
   this._httpServer.timeout = 0; // clients expect to hold connections open as long as they want
-  this._httpServer.listen(this._httpPort);
   this._httpServer.on('listening', this._onHttpServerListening.bind(this));
   this._httpServer.on('request', this._onHttpServerRequest.bind(this));
-  this._httpServer.on('close', this._onHttpServerClose.bind(this));
+  this._httpServer.on('error', this._onHttpServerError.bind(this));
+  this._httpServer.listen(0);
   
   // an arbitrary dict that users of this class can store values in to associate with this particular connection
   this._session = {};
@@ -193,8 +192,12 @@ EventedHTTPServerConnection.prototype._sendPendingEvents = function() {
 
 // Called only once right after constructor finishes
 EventedHTTPServerConnection.prototype._onHttpServerListening = function() {
-  debug("[%s] HTTP server listening on port %s", this._remoteAddress, this._httpServer.address().port);
-  
+  this._httpPort = this._httpServer.address().port;
+  debug("[%s] HTTP server listening on port %s", this._remoteAddress, this._httpPort);
+
+  // closes before this are due to retrying listening, which don't need to be handled
+  this._httpServer.on('close', this._onHttpServerClose.bind(this));
+
   // now we can establish a connection to this running HTTP server for proxying data
   this._serverSocket = net.createConnection(this._httpPort);
   this._serverSocket.on('connect', this._onServerSocketConnect.bind(this));
@@ -289,11 +292,17 @@ EventedHTTPServerConnection.prototype._onHttpServerRequest = function(request, r
 EventedHTTPServerConnection.prototype._onHttpServerClose = function() {
   debug("[%s] HTTP server was closed", this._remoteAddress);
   
-  // release our port for others to use
-  PortAllocator.releasePort(this._httpPort);
-  
   // notify listeners that we are completely closed
   this.emit('close');
+}
+
+EventedHTTPServerConnection.prototype._onHttpServerError = function(err) {
+  debug("[%s] HTTP server error: %s", this._remoteAddress, err.message);
+
+  if (err.code === 'EADDRINUSE') {
+    this._httpServer.close();
+    this._httpServer.listen(0);
+  }
 }
 
 EventedHTTPServerConnection.prototype._onClientSocketClose = function() {
@@ -308,28 +317,3 @@ EventedHTTPServerConnection.prototype._onClientSocketError = function(err) {
   
   // _onClientSocketClose will be called next
 }
-
-
-/**
- * Manages a pool of available ports for our internal HTTP servers and allows for reuse.
- */
-
-var PortAllocator = {
-  initialPort: 54826, // first port to use; subsequent ports will increment from this
-  portsInUse: {}, // sparse array of ports in use
-  
-  allocatePort: function() {
-    
-    // start with our initial port; increment until we find an open slot
-    var nextPort = PortAllocator.initialPort;
-    while (PortAllocator.portsInUse[nextPort]) nextPort++;
-    
-    // claim the slot and return the port
-    PortAllocator.portsInUse[nextPort] = true;
-    return nextPort;
-  },
-  
-  releasePort: function(port) {
-    delete PortAllocator.portsInUse[port];
-  }
-};


### PR DESCRIPTION
This version actually tries a different port if the OS-generated port is in use...