### PR TITLE
Allow to getService by subtype string

### DIFF
--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -189,7 +189,7 @@ Accessory.prototype.getService = function(name) {
   for (var index in this.services) {
     var service = this.services[index];
     
-    if (typeof name === 'string' && (service.displayName === name || service.name === name))
+    if (typeof name === 'string' && (service.displayName === name || service.name === name || service.subtype === name))
       return service;
     else if (typeof name === 'function' && ((service instanceof name) || (name.UUID === service.UUID)))
       return service;


### PR DESCRIPTION
Okay if there’s a reason not to do this, just seemed like it would be handy. I’m going to iterate `services` in client code to do the same thing. I suppose this could potentially be a breaking change, even with it as the last `||`, but probably very unlikely that it would break anything.