### PR TITLE
replaces node-persist by persist-json

### DIFF
--- a/BridgedCore.js
+++ b/BridgedCore.js
@@ -1,15 +1,11 @@
 var fs = require('fs');
 var path = require('path');
-var storage = require('node-persist');
 var uuid = require('./').uuid;
 var Bridge = require('./').Bridge;
 var Accessory = require('./').Accessory;
 var accessoryLoader = require('./lib/AccessoryLoader');
 
 console.log("HAP-NodeJS starting...");
-
-// Initialize our storage system
-storage.initSync();
 
 // Start by creating our Bridge which will host all loaded Accessories
 var bridge = new Bridge('Node Bridge', uuid.generate("Node Bridge"));

--- a/Core.js
+++ b/Core.js
@@ -1,13 +1,9 @@
 var path = require('path');
-var storage = require('node-persist');
 var uuid = require('./').uuid;
 var Accessory = require('./').Accessory;
 var accessoryLoader = require('./lib/AccessoryLoader');
 
 console.log("HAP-NodeJS starting...");
-
-// Initialize our storage system
-storage.initSync();
 
 // Our Accessories will each have their own HAP server; we will assign ports sequentially
 var targetPort = 51826;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var Service = require('./lib/Service.js').Service;
 var Characteristic = require('./lib/Characteristic.js').Characteristic;
 var uuid = require('./lib/util/uuid');
 var AccessoryLoader = require('./lib/AccessoryLoader.js');
-var storage = require('node-persist');
 
 // ensure Characteristic subclasses are defined
 var HomeKitTypes = require('./lib/gen/HomeKitTypes');
@@ -17,12 +16,9 @@ module.exports = {
   Characteristic: Characteristic,
   uuid: uuid,
   AccessoryLoader: AccessoryLoader
-}
+};
 
-function init(storagePath) {
-  // initialize our underlying storage system, passing on the directory if needed
-  if (typeof storagePath !== 'undefined')
-    storage.initSync({ dir: storagePath });
-  else
-    storage.initSync(); // use whatever is default
+function init() {
+  // left for downwards compatibility
+  console.log('WARNING - storagePath option removed');
 }

--- a/lib/AccessoryLoader.js
+++ b/lib/AccessoryLoader.js
@@ -4,7 +4,6 @@ var Accessory = require('./Accessory').Accessory;
 var Service = require('./Service').Service;
 var Characteristic = require('./Characteristic').Characteristic;
 var uuid = require('./util/uuid');
-var storage = require('node-persist');
 
 module.exports = {
   loadDirectory: loadDirectory,

--- a/lib/model/AccessoryInfo.js
+++ b/lib/model/AccessoryInfo.js
@@ -1,4 +1,4 @@
-var storage = require('node-persist');
+var storage = require('persist-json')('hap-nodejs');
 var util = require('util');
 var crypto = require('crypto');
 var ed25519 = require('ed25519');
@@ -100,7 +100,7 @@ AccessoryInfo.create = function(username) {
 
 AccessoryInfo.load = function(username) {
   var key = AccessoryInfo.persistKey(username);
-  var saved = storage.getItem(key);
+  var saved = storage.load(key);
   
   if (saved) {
     var info = new AccessoryInfo(username);
@@ -160,6 +160,5 @@ AccessoryInfo.prototype.save = function() {
   
   var key = AccessoryInfo.persistKey(this.username);
   
-  storage.setItemSync(key, saved);
-  storage.persistSync();
+  storage.save(key, saved);
 }

--- a/lib/model/IdentifierCache.js
+++ b/lib/model/IdentifierCache.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var storage = require('node-persist');
+var storage = require('persist-json')('hap-nodejs');
 
 'use strict';
 
@@ -100,7 +100,7 @@ IdentifierCache.persistKey = function(username) {
 
 IdentifierCache.load = function(username) {
   var key = IdentifierCache.persistKey(username);
-  var saved = storage.getItem(key);
+  var saved = storage.load(key);
   
   if (saved) {
     var info = new IdentifierCache(username);
@@ -119,6 +119,5 @@ IdentifierCache.prototype.save = function() {
   
   var key = IdentifierCache.persistKey(this.username);
   
-  storage.setItemSync(key, saved);
-  storage.persistSync();
+  storage.save(key, saved);
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "debug": "^2.2.0",
     "ed25519": "git://github.com/KhaosT/ed25519",
     "mdns": "^2.3.2",
-    "node-persist": "^0.0.8",
+    "persist-json": "^1.0.1",
     "srp": "git://github.com/KhaosT/node-srp"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace node-persist by persist-json. This provides a more convenient way to store data in an OS-specific reasonable path by default and prevents issues when the user running hap-nodejs has no write-access to the node_modules/node-persist folder. 
Will by default create a Folder ~/.hap-nodejs/ on Linux and ~/Library/Preferences/hap-nodejs on macOS.