### PR TITLE
Fix Apple DMCA link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See each of the corresponding class files for more explanation and notes.
 Notes
 =====
 
-Special thanks to [Alex Skalozub](https://twitter.com/pieceofsummer), who reverse engineered the server side HAP. ~~You can find his research at [here](https://gist.github.com/pieceofsummer/13272bf76ac1d6b58a30).~~ (Sadly, on Nov 4, Apple sent the [DMCA](https://github.com/github/dmca/blob/master/2014-11-04-Apple.md) request to Github to remove the research.)
+Special thanks to [Alex Skalozub](https://twitter.com/pieceofsummer), who reverse engineered the server side HAP. ~~You can find his research at [here](https://gist.github.com/pieceofsummer/13272bf76ac1d6b58a30).~~ (Sadly, on Nov 4, Apple sent the [DMCA](https://github.com/github/dmca/blob/master/2014/2014-11-04-Apple.md) request to Github to remove the research.)
 
 [There](http://instagram.com/p/t4cPlcDksQ/) is a video demo running this project on Intel Edison.
 


### PR DESCRIPTION
The link to Apple's DMCA was broken. Presumably GitHub updated the folder structure in their DMCA repo. This PR fixes the link in the readme.