### PR TITLE
localStorage is not defined when included as a submodule

### DIFF
--- a/lib/model/AccessoryInfo.js
+++ b/lib/model/AccessoryInfo.js
@@ -10,6 +10,9 @@ module.exports = {
   AccessoryInfo: AccessoryInfo
 };
 
+// Initialize our storage system
+storage.initSync();
+
 
 /**
  * AccessoryInfo is a model class containing a subset of Accessory data relevant to the internal HAP server,


### PR DESCRIPTION
When trying to run this as a submodule (with the core not in the base of the repo) I encountered errors where `localStorage` was not defined on node-persist. I believe this to be because the storage was never initialised in the `AccessoryInfo` model. I have added that in and the module now appears to behave as expected in normal use and how I am trying to use HAP-NodeJS.

```
/home/msh/Broadlink-HomeKit/HAP-NodeJS/node_modules/node-persist/node-persist.js:111
        return localStorage.getItemSync(key);
                           ^

TypeError: Cannot read property 'getItemSync' of undefined
    at Object.nodePersist.getItemSync (/home/msh/Broadlink-HomeKit/HAP-NodeJS/node_modules/node-persist/node-persist.js:111:28)
    at Function.AccessoryInfo.load (/home/msh/Broadlink-HomeKit/HAP-NodeJS/lib/model/AccessoryInfo.js:103:23)
    at Bridge.Accessory.publish (/home/msh/Broadlink-HomeKit/HAP-NodeJS/lib/Accessory.js:427:39)
    at Object.<anonymous> (/home/msh/Broadlink-HomeKit/BroadlinkCore.js:34:8)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
```