### PR TITLE
catch mdns error

### DIFF
--- a/lib/Advertiser.js
+++ b/lib/Advertiser.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var mdns = require('mdns');
+var debug = require('debug')('Advertiser');
 
 module.exports = {
   Advertiser: Advertiser
@@ -40,11 +41,15 @@ Advertiser.prototype.startAdvertising = function(port) {
   };
 
   // create/recreate our advertisement
-  this._advertisement = mdns.createAdvertisement(mdns.tcp('hap'), port, {
-    name: this.accessoryInfo.displayName,
-    txtRecord: txtRecord
-  });
-  this._advertisement.start();
+  try {
+    this._advertisement = mdns.createAdvertisement(mdns.tcp('hap'), port, {
+      name: this.accessoryInfo.displayName,
+      txtRecord: txtRecord
+    });
+    this._advertisement.start();
+  } catch (err) {
+    debug('mdns issue %o', err);
+  }
 }
 
 Advertiser.prototype.isAdvertising = function() {


### PR DESCRIPTION
I do have some issues with mdns. anyway - this PR catches the mdns error and sends out a debug message.

`
Advertiser mdns issue { Error: dns service error: unknown at Error (native) at new Advertisement (/opt/node_modules/mdns/lib/advertisement.js:56:10) at Object.create [as createAdvertisement] (/opt/node_modules/mdns/lib/advertisement.js:64:10) at Advertiser.startAdvertising (/opt/node_modules/hap-nodejs/lib/Advertiser.js:45:30) at Bridge.Accessory._onListening (/opt/node_modules/hap-nodejs/lib/Accessory.js:549:20) at emitOne (events.js:96:13) at HAPServer.emit (events.js:188:7) at HAPServer._onListening (/opt/node_modules/hap-nodejs/lib/HAPServer.js:190:8) at emitOne (events.js:96:13) at EventedHTTPServer.emit (events.js:188:7) at EventedHTTPServer.<anonymous> (/opt/node_modules/hap-nodejs/lib/util/eventedhttp.js:65:10) at emitNone (events.js:86:13) at Server.emit (events.js:185:7) at emitListeningNT (net.js:1285:10) at _combinedTickCallback (internal/process/next_tick.js:71:11) at process._tickCallback (internal/process/next_tick.js:98:9) errorCode: -65537 } +25s`

or do you have a better idea to handle this error? ill investigate further why this happens - I have a working avahi server running on this ARM machine