### PR TITLE
change curve25519-n to curve25519-n2 to support Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "buffer-shims": "^1.0.0",
-    "curve25519-n": "^1.1.0",
+    "curve25519-n2": "^1.1.2",
     "debug": "^2.2.0",
     "ed25519": "^0.0.4",
     "fast-srp-hap": "^1.0.0",


### PR DESCRIPTION
curve25519-n isn't building on Windows 10. curve25519-n2 includes code to handle building on Windows 10. There are no other changes.