### PR TITLE
Updates for IOS 11 / XCode 9

### DIFF
--- a/accessories/AirConditioner_accessory.js
+++ b/accessories/AirConditioner_accessory.js
@@ -145,6 +145,5 @@ LightService.getCharacteristic(Characteristic.On)
       console.log( "Characteristic Light On changed to %s",value);
       callback();
     });
-LightService.setHiddenService(false);
-
+LightService.setHiddenService(true);
 ACTest.setPrimaryService(ThermostatService);

--- a/accessories/AirConditioner_accessory.js
+++ b/accessories/AirConditioner_accessory.js
@@ -1,0 +1,150 @@
+var Accessory = require('../').Accessory;
+var Service = require('../').Service;
+var Characteristic = require('../').Characteristic;
+var uuid = require('../').uuid;
+
+//In This example we create an Airconditioner Accessory that Has a Thermostat linked to a Fan Service.
+//For example, I've also put a Light Service that should be hidden to represent a light in the closet that is part of the AC. It is to show how to hide services.
+//The linking and Hiding does NOT appear to be reflected in Home
+
+// here's a fake hardware device that we'll expose to HomeKit
+var ACTest_data = {
+  fanPowerOn: false,
+  rSpeed: 100,
+  CurrentHeatingCoolingState: 1,
+  TargetHeatingCoolingState: 1,
+  CurrentTemperature: 33,
+  TargetTemperature: 32,
+  TemperatureDisplayUnits: 1,
+  LightOn: false
+}
+
+// This is the Accessory that we'll return to HAP-NodeJS that represents our fake fan.
+var ACTest = exports.accessory = new Accessory('Fan', uuid.generate('hap-nodejs:accessories:Fan'));
+
+// Add properties for publishing (in case we're using Core.js and not BridgedCore.js)
+ACTest.username = "1A:2B:3C:4D:5E:FF";
+ACTest.pincode = "031-45-154";
+
+// set some basic properties (these values are arbitrary and setting them is optional)
+ACTest
+  .getService(Service.AccessoryInformation)
+  .setCharacteristic(Characteristic.Manufacturer, "Sample Company")
+
+// listen for the "identify" event for this Accessory
+ACTest.on('identify', function(paired, callback) {
+  console.log("Fan Identified!");
+  callback(); // success
+});
+
+// Add the actual Fan Service and listen for change events from iOS.
+// We can see the complete list of Services and Characteristics in `lib/gen/HomeKitTypes.js`
+
+var FanService = ACTest.addService(Service.Fan, "Blower") // services exposed to the user should have "names" like "Fake Light" for us
+FanService.getCharacteristic(Characteristic.On)
+  .on('set', function(value, callback) {
+    console.log("Fan Power Changed To "+value);
+    ACTest_data.fanPowerOn=value
+    callback(); // Our fake Fan is synchronous - this value has been successfully set
+  });
+
+// We want to intercept requests for our current power state so we can query the hardware itself instead of
+// allowing HAP-NodeJS to return the cached Characteristic.value.
+FanService.getCharacteristic(Characteristic.On)
+  .on('get', function(callback) {
+
+    // this event is emitted when you ask Siri directly whether your fan is on or not. you might query
+    // the fan hardware itself to find this out, then call the callback. But if you take longer than a
+    // few seconds to respond, Siri will give up.
+
+    var err = null; // in case there were any problems
+
+    if (ACTest_data.fanPowerOn) {
+      callback(err, true);
+    }
+    else {
+      callback(err, false);
+    }
+  });
+
+
+// also add an "optional" Characteristic for spped
+FanService.addCharacteristic(Characteristic.RotationSpeed)
+  .on('get', function(callback) {
+    callback(null, ACTest_data.rSpeed);
+  })
+  .on('set', function(value, callback) {
+    console.log("Setting fan rSpeed to %s", value);
+    ACTest_data.rSpeed=value
+    callback();
+  })
+
+var ThermostatService = ACTest.addService(Service.Thermostat,"Thermostat");
+ThermostatService.addLinkedService(FanService);
+
+ThermostatService.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+
+  .on('get', function(callback) {
+    callback(null, ACTest_data.CurrentHeatingCoolingState);
+  })
+  .on('set',function(value, callback) {
+      ACTest_data.CurrentHeatingCoolingState=value;
+      console.log( "Characteristic CurrentHeatingCoolingState changed to %s",value);
+      callback();
+    });
+
+ ThermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState)
+  .on('get', function(callback) {
+    callback(null, ACTest_data.TargetHeatingCoolingState);
+  })
+  .on('set',function(value, callback) {
+      ACTest_data.TargetHeatingCoolingState=value;
+      console.log( "Characteristic TargetHeatingCoolingState changed to %s",value);
+      callback();
+    });
+
+ ThermostatService.getCharacteristic(Characteristic.CurrentTemperature)
+  .on('get', function(callback) {
+    callback(null, ACTest_data.CurrentTemperature);
+  })
+  .on('set',function(value, callback) {
+      ACTest_data.CurrentTemperature=value;
+      console.log( "Characteristic CurrentTemperature changed to %s",value);
+      callback();
+    });
+
+ ThermostatService.getCharacteristic(Characteristic.TargetTemperature)
+  .on('get', function(callback) {
+    callback(null, ACTest_data.TargetTemperature);
+  })
+  .on('set',function(value, callback) {
+      ACTest_data.TargetTemperature=value;
+      console.log( "Characteristic TargetTemperature changed to %s",value);
+      callback();
+    });
+
+ ThermostatService.getCharacteristic(Characteristic.TemperatureDisplayUnits)
+  .on('get', function(callback) {
+    callback(null, ACTest_data.TemperatureDisplayUnits);
+  })
+  .on('set',function(value, callback) {
+      ACTest_data.TemperatureDisplayUnits=value;
+      console.log( "Characteristic TemperatureDisplayUnits changed to %s",value);
+      callback();
+    });
+    
+
+
+var LightService = ACTest.addService(Service.Lightbulb, 'AC Light');
+LightService.getCharacteristic(Characteristic.On)
+    .on('get', function(callback) {
+      callback(null, ACTest_data.LightOn);
+    })
+    .on('set', function(value, callback) {
+      ACTest_data.LightOn=value;
+      console.log( "Characteristic Light On changed to %s",value);
+      callback();
+    });
+LightService.setHiddenService(false);
+
+ACTest.setPrimaryService(ThermostatService);

--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -103,12 +103,11 @@ Accessory.Categories = {
   CAMERA: 17,
   IP_CAMERA: 17, //Added to conform to HAP naming
   VIDEO_DOORBELL: 18,
-  AIR_PURIFIER: 19
-  //20+ is marked as reserved in the official protocol spec
-  //AIR_HEATER: 20,
-  //AIR_CONDITIONER: 21,
-  //AIR_HUMIDIFIER: 22,
-  //AIR_DEHUMIDIFIER: 23
+  AIR_PURIFIER: 19,
+  AIR_HEATER: 20, //Not in HAP Spec
+  AIR_CONDITIONER: 21, //Not in HAP Spec
+  AIR_HUMIDIFIER: 22, //Not in HAP Spec
+  AIR_DEHUMIDIFIER: 23 // Not in HAP Spec
 }
 
 Accessory.prototype._identificationRequest = function(paired, callback) {

--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -94,18 +94,21 @@ Accessory.Categories = {
   THERMOSTAT: 9,
   SENSOR: 10,
   ALARM_SYSTEM: 11,
+  SECURITY_SYSTEM: 11, //Added to conform to HAP naming
   DOOR: 12,
   WINDOW: 13,
   WINDOW_COVERING: 14,
   PROGRAMMABLE_SWITCH: 15,
   RANGE_EXTENDER: 16,
   CAMERA: 17,
+  IP_CAMERA: 17, //Added to conform to HAP naming
   VIDEO_DOORBELL: 18,
-  AIR_PURIFIER: 19,
-  AIR_HEATER: 20,
-  AIR_CONDITIONER: 21,
-  AIR_HUMIDIFIER: 22,
-  AIR_DEHUMIDIFIER: 23
+  AIR_PURIFIER: 19
+  //20+ is marked as reserved in the official protocol spec
+  //AIR_HEATER: 20,
+  //AIR_CONDITIONER: 21,
+  //AIR_HUMIDIFIER: 22,
+  //AIR_DEHUMIDIFIER: 23
 }
 
 Accessory.prototype._identificationRequest = function(paired, callback) {
@@ -168,6 +171,34 @@ Accessory.prototype.addService = function(service) {
   }.bind(this));
 
   return service;
+}
+
+Accessory.prototype.setPrimaryService = function (service) {
+    //find this service in the services list
+    var targetServiceIndex;
+    for (var index in this.services) {
+        var existingService = this.services[index];
+
+        if (existingService === service) {
+            targetServiceIndex = index;
+            break;
+        }
+    }
+     
+    if (targetServiceIndex) {
+        //If the service is found, set isPrimaryService to false for everything.
+        for (var index in this.services)
+            this.services[index].isPrimaryService = false;
+
+        //Make this service the primary
+        existingService.isPrimaryService = true
+
+        if (!this.bridged) {
+            this._updateConfiguration();
+        } else {
+            this.emit('service-configurationChange', clone({ accessory: this, service: service }));
+        }
+    }
 }
 
 Accessory.prototype.removeService = function(service) {

--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -70,7 +70,9 @@ Characteristic.Formats = {
   UINT32: 'uint32',
   UINT64: 'uint64',
   DATA: 'data',
-  TLV8: 'tlv8'
+  TLV8: 'tlv8',
+  ARRAY: 'array', //Not in HAP Spec
+  DICTIONARY: 'dictionary' //Not in HAP Spec
 }
 
 // Known HomeKit unit types
@@ -92,7 +94,7 @@ Characteristic.Perms = {
   NOTIFY: 'ev', //Kept for backwards compatability
   EVENTS: 'ev', //Added to match HAP's terminology
   ADDITIONAL_AUTHORIZATION: 'aa',
-  TIMED_WRITE: 'tw',
+  TIMED_WRITE: 'tw', //Not currently supported by IP
   HIDDEN: 'hd'
 }
 
@@ -143,19 +145,18 @@ Characteristic.prototype.getValue = function(callback, context, connectionID) {
         if (callback) callback(err);
       }
       else {
-        if (this.validateValue(newValue)) {
-          if (newValue === undefined || newValue === null)
-            newValue = this.getDefaultValue();
+        newValue = this.validateValue(newValue); //validateValue returns a value that has be cooerced into a valid value.
+        if (newValue === undefined || newValue === null)
+          newValue = this.getDefaultValue();
 
-          // getting the value was a success; we can pass it along and also update our cached value
-          var oldValue = this.value;
-          this.value = newValue;
-          if (callback) callback(null, newValue);
+        // getting the value was a success; we can pass it along and also update our cached value
+        var oldValue = this.value;
+        this.value = newValue;
+        if (callback) callback(null, newValue);
 
-          // emit a change event if necessary
-          if (oldValue !== newValue)
-            this.emit('change', { oldValue:oldValue, newValue:newValue, context:context });
-        }
+        // emit a change event if necessary
+        if (oldValue !== newValue)
+          this.emit('change', { oldValue:oldValue, newValue:newValue, context:context });
       }
 
     }.bind(this)), context, connectionID);
@@ -174,9 +175,9 @@ Characteristic.prototype.validateValue = function(newValue) {
  var minValue_resolved = 0;
  var maxValue_resolved = 0;
  var minStep_resolved = undefined;
+ var stepDecimals = 0;
+
   switch(this.props.format) {
-    case 'bool':
-      break;
     case 'int':
       minStep_resolved=1;
       minValue_resolved=-2147483648;
@@ -188,12 +189,6 @@ Characteristic.prototype.validateValue = function(newValue) {
       minValue_resolved=undefined;
       maxValue_resolved=undefined;
       isNumericType=true;
-      break;
-    case 'string':
-      var myString = newValue;
-      var maxLength = this.props.maxLen;
-      if (maxLength===undefined) maxLength=64; //Default Max Length is 64.
-      if (myString.length>maxLength) throw new Error('Characteristic ' + this.displayName + ' Failed Length Validation');
       break;
     case 'uint8':
       minStep_resolved=1;
@@ -219,41 +214,63 @@ Characteristic.prototype.validateValue = function(newValue) {
       maxValue_resolved=18446744073709551615;
       isNumericType=true;
       break;
+    //All of the following datatypes return from this switch.    
+     case 'bool':
+      return newValue; //We don't need to do any validation
+      break;
+    case 'string':
+      var myString = newValue;
+      var maxLength = this.props.maxLen;
+      if (maxLength===undefined) maxLength=64; //Default Max Length is 64.
+      if (myString.length>maxLength) myString = myString.substring(0,maxLength); //Truncate strings that are too long
+      return myString; //We don't need to do any validation after having truncated the string   
+      break;
     case 'data':
       var maxLength = this.props.maxDataLen;
       if (maxLength===undefined) maxLength=2097152; //Default Max Length is 2097152.
-      if (newValue.length>maxLength) throw new Error('Characteristic ' + this.displayName + ' Failed Length Validation');
+      //if (newValue.length>maxLength) //I don't know the best way to handle this since it's unknown binary data.
+      //I suspect that it will crash HomeKit for this bridge if the length is too long.
+      return newValue;
       break;
     case 'tlv8':
       //Should we parse this to make sure the tlv8 is valid?
       break;
-    default:
-      throw new Error('Characteristic ' + this.displayName + ' Unknown DataType');
+    default: //Datatype out of HAP Spec encountered. We'll assume the developer knows what they're doing.
+      return newValue;
     };
     
   if (isNumericType) {
-    if (isNaN(newValue)) throw new Error('Characteristic ' + this.displayName + ' Value Is Not A Number');; //This is not a number.
+    if (isNaN(newValue)) return this.value; //This is not a number so we'll just pass out the last value.
     if ((!isNaN(this.props.maxValue))&&(this.props.maxValue!==null)) maxValue_resolved=this.props.maxValue;
     if ((!isNaN(this.props.minValue))&&(this.props.minValue!==null)) minValue_resolved=this.props.minValue;
     if ((!isNaN(this.props.minStep))&&(this.props.minStep!==null)) minStep_resolved=this.props.minStep;
-    
-    if (newValue<minValue_resolved) throw new Error('Characteristic ' + this.displayName + ' Is Below Minimum');; //Fails Minimum Value Test
-    if (newValue>maxValue_resolved) throw new Error('Characteristic ' + this.displayName + ' Is Above Maximum');; //Fails Maximum Value Test
-    if (minStep_resolved!==undefined)
-      if (((newValue-minValue_resolved) % minStep_resolved).toFixed(10)!=0) throw new Error('Characteristic ' + this.displayName + ' Is Out Of Valid Step');; //Fails Step/Integer Test
-    //The above line is odd because I had issues with the fload having an off value of 1 x 10^16.
+  
+    if (newValue<minValue_resolved) newValue=minValue_resolved; //Fails Minimum Value Test
+    if (newValue>maxValue_resolved) newValue=maxValue_resolved; //Fails Maximum Value Test
+    if (minStep_resolved!==undefined) {
+      if (Math.floor(minStep_resolved) === minStep_resolved) 
+        stepDecimals = 0;
+      else
+        stepDecimals = minStep_resolved.toString().split(".")[1].length || 0;
+      //Now that we know how many decimals, we need to scale the values to better handle precision.
+      var valueDiffFromMin_scaled = ((newValue-minValue_resolved)*Math.pow(10,stepDecimals));
+      var minStep_scaled = (minStep_resolved*Math.pow(10,stepDecimals));
+      valueDiffFromMin_scaled -= valueDiffFromMin_scaled % minStep_scaled; //This rounds  the value to the closest lower step.
+      newValue=(valueDiffFromMin_scaled/Math.pow(10,stepDecimals))+minValue_resolved //Convert this to the unscaled value.
+    }
 
     if (this['valid-values']!==undefined) 
-      if (!this['valid-values'].includes(newValue)) throw new Error('Characteristic ' + this.displayName + ' Is Not In Valid Values');; //Fails Valid Values Test
-    if (this['valid-values-range']!==undefined) 
-      if ((newValue<this['valid-values-range'][0])||(newValue>this['valid-values-range'][1])) throw new Error('Characteristic ' + this.displayName + ' Is Out Of Valid Range');; //Fails Valid Values Test
+      if (!this['valid-values'].includes(newValue)) return this.value; //Fails Valid Values Test
+    if (this['valid-values-range']!==undefined) { //This is another way Apple has to handle min/max
+      if (newValue<this['valid-values-range'][0]) newValue=this['valid-values-range'][0];
+      if (newValue>this['valid-values-range'][1]) newValue=this['valid-values-range'][1];
+    }
   }
-  return true;
+  return newValue;
 }
 
 Characteristic.prototype.setValue = function(newValue, callback, context, connectionID) {
-  if (!this.validateValue(newValue))
-    return; //Need to throw an error instead
+  newValue = this.validateValue(newValue); //validateValue returns a value that has be cooerced into a valid value.
 
   if (this.listeners('set').length > 0) {
 
@@ -295,8 +312,7 @@ Characteristic.prototype.setValue = function(newValue, callback, context, connec
 }
 
 Characteristic.prototype.updateValue = function(newValue, callback, context) {
-  if (!this.validateValue(newValue))
-    return; //Need to throw an error instead
+  newValue = this.validateValue(newValue); //validateValue returns a value that has be cooerced into a valid value.
   
   if (newValue === undefined || newValue === null)
     newValue = this.getDefaultValue();
@@ -314,10 +330,8 @@ Characteristic.prototype.getDefaultValue = function() {
   switch (this.props.format) {
     case Characteristic.Formats.BOOL: return false;
     case Characteristic.Formats.STRING: return "";
-    case Characteristic.Formats.ARRAY: return []; // who knows!
-    case Characteristic.Formats.DICTIONARY: return {}; // who knows!
-    case Characteristic.Formats.DATA: return ""; // who knows!
-    case Characteristic.Formats.TLV8: return ""; // who knows!
+    case Characteristic.Formats.DATA: return null; // who knows!
+    case Characteristic.Formats.TLV8: return null; // who knows!
     default: return this.props.minValue || 0;
   }
 }

--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -65,13 +65,11 @@ Characteristic.Formats = {
   INT: 'int',
   FLOAT: 'float',
   STRING: 'string',
-  ARRAY: 'array', // unconfirmed
-  DICTIONARY: 'dictionary', // unconfirmed
   UINT8: 'uint8',
   UINT16: 'uint16',
   UINT32: 'uint32',
   UINT64: 'uint64',
-  DATA: 'data', // unconfirmed
+  DATA: 'data',
   TLV8: 'tlv8'
 }
 
@@ -87,9 +85,14 @@ Characteristic.Units = {
 
 // Known HomeKit permission types
 Characteristic.Perms = {
-  READ: 'pr',
-  WRITE: 'pw',
-  NOTIFY: 'ev',
+  READ: 'pr', //Kept for backwards compatability
+  PAIRED_READ: 'pr', //Added to match HAP's terminology
+  WRITE: 'pw', //Kept for backwards compatability
+  PAIRED_WRITE: 'pw', //Added to match HAP's terminology
+  NOTIFY: 'ev', //Kept for backwards compatability
+  EVENTS: 'ev', //Added to match HAP's terminology
+  ADDITIONAL_AUTHORIZATION: 'aa',
+  TIMED_WRITE: 'tw',
   HIDDEN: 'hd'
 }
 
@@ -100,12 +103,19 @@ Characteristic.Perms = {
  * @param 'props' {
  *   format: <one of Characteristic.Formats>,
  *   unit: <one of Characteristic.Units>,
- *   minValue: <minimum value for numeric characteristics>,
- *   maxValue: <maximum value for numeric characteristics>,
- *   minStep: <smallest allowed increment for numeric characteristics>,
  *   perms: array of [Characteristic.Perms] like [Characteristic.Perms.READ, Characteristic.Perms.WRITE]
+ *   ev: <Event Notifications Enabled Boolean>, (Optional)
+ *   description: <String of description>, (Optional)
+ *   minValue: <minimum value for numeric characteristics>, (Optional)
+ *   maxValue: <maximum value for numeric characteristics>, (Optional)
+ *   minStep: <smallest allowed increment for numeric characteristics>, (Optional)
+ *   maxLen: <max length of string up to 256>, (Optional default: 64)
+ *   maxDataLen: <max length of data>, (Optional default: 2097152)
+ *   valid-values: <array of numbers>, (Optional)
+ *   valid-values-range: <array of two numbers for start and end range> (Optional)
  * }
  */
+
 Characteristic.prototype.setProps = function(props) {
   for (var key in (props || {}))
     if (Object.prototype.hasOwnProperty.call(props, key))
@@ -133,17 +143,19 @@ Characteristic.prototype.getValue = function(callback, context, connectionID) {
         if (callback) callback(err);
       }
       else {
-        if (newValue === undefined || newValue === null)
-          newValue = this.getDefaultValue();
+        if (this.validateValue(newValue)) {
+          if (newValue === undefined || newValue === null)
+            newValue = this.getDefaultValue();
 
-        // getting the value was a success; we can pass it along and also update our cached value
-        var oldValue = this.value;
-        this.value = newValue;
-        if (callback) callback(null, newValue);
+          // getting the value was a success; we can pass it along and also update our cached value
+          var oldValue = this.value;
+          this.value = newValue;
+          if (callback) callback(null, newValue);
 
-        // emit a change event if necessary
-        if (oldValue !== newValue)
-          this.emit('change', { oldValue:oldValue, newValue:newValue, context:context });
+          // emit a change event if necessary
+          if (oldValue !== newValue)
+            this.emit('change', { oldValue:oldValue, newValue:newValue, context:context });
+        }
       }
 
     }.bind(this)), context, connectionID);
@@ -156,7 +168,92 @@ Characteristic.prototype.getValue = function(callback, context, connectionID) {
   }
 }
 
+Characteristic.prototype.validateValue = function(newValue) {
+
+ var isNumericType = false;
+ var minValue_resolved = 0;
+ var maxValue_resolved = 0;
+ var minStep_resolved = undefined;
+  switch(this.props.format) {
+    case 'bool':
+      break;
+    case 'int':
+      minStep_resolved=1;
+      minValue_resolved=-2147483648;
+      maxValue_resolved=2147483647;
+      isNumericType=true;
+      break;
+    case 'float':
+      minStep_resolved=undefined;
+      minValue_resolved=undefined;
+      maxValue_resolved=undefined;
+      isNumericType=true;
+      break;
+    case 'string':
+      var myString = newValue;
+      var maxLength = this.props.maxLen;
+      if (maxLength===undefined) maxLength=64; //Default Max Length is 64.
+      if (myString.length>maxLength) throw new Error('Characteristic ' + this.displayName + ' Failed Length Validation');
+      break;
+    case 'uint8':
+      minStep_resolved=1;
+      minValue_resolved=0;
+      maxValue_resolved=255;
+      isNumericType=true;
+      break;
+    case 'uint16':
+      minStep_resolved=1;
+      minValue_resolved=0;
+      maxValue_resolved=65535;
+      isNumericType=true;
+      break;
+    case 'uint32':
+      minStep_resolved=1;
+      minValue_resolved=0;
+      maxValue_resolved=4294967295;
+      isNumericType=true;
+      break;
+    case 'uint64':
+      minStep_resolved=1;
+      minValue_resolved=0;
+      maxValue_resolved=18446744073709551615;
+      isNumericType=true;
+      break;
+    case 'data':
+      var maxLength = this.props.maxDataLen;
+      if (maxLength===undefined) maxLength=2097152; //Default Max Length is 2097152.
+      if (newValue.length>maxLength) throw new Error('Characteristic ' + this.displayName + ' Failed Length Validation');
+      break;
+    case 'tlv8':
+      //Should we parse this to make sure the tlv8 is valid?
+      break;
+    default:
+      throw new Error('Characteristic ' + this.displayName + ' Unknown DataType');
+    };
+    
+  if (isNumericType) {
+    if (isNaN(newValue)) throw new Error('Characteristic ' + this.displayName + ' Value Is Not A Number');; //This is not a number.
+    if ((!isNaN(this.props.maxValue))&&(this.props.maxValue!==null)) maxValue_resolved=this.props.maxValue;
+    if ((!isNaN(this.props.minValue))&&(this.props.minValue!==null)) minValue_resolved=this.props.minValue;
+    if ((!isNaN(this.props.minStep))&&(this.props.minStep!==null)) minStep_resolved=this.props.minStep;
+    
+    if (newValue<minValue_resolved) throw new Error('Characteristic ' + this.displayName + ' Is Below Minimum');; //Fails Minimum Value Test
+    if (newValue>maxValue_resolved) throw new Error('Characteristic ' + this.displayName + ' Is Above Maximum');; //Fails Maximum Value Test
+    if (minStep_resolved!==undefined)
+      if (((newValue-minValue_resolved) % minStep_resolved).toFixed(10)!=0) throw new Error('Characteristic ' + this.displayName + ' Is Out Of Valid Step');; //Fails Step/Integer Test
+    //The above line is odd because I had issues with the fload having an off value of 1 x 10^16.
+
+    if (this['valid-values']!==undefined) 
+      if (!this['valid-values'].includes(newValue)) throw new Error('Characteristic ' + this.displayName + ' Is Not In Valid Values');; //Fails Valid Values Test
+    if (this['valid-values-range']!==undefined) 
+      if ((newValue<this['valid-values-range'][0])||(newValue>this['valid-values-range'][1])) throw new Error('Characteristic ' + this.displayName + ' Is Out Of Valid Range');; //Fails Valid Values Test
+  }
+  return true;
+}
+
 Characteristic.prototype.setValue = function(newValue, callback, context, connectionID) {
+  if (!this.validateValue(newValue))
+    return; //Need to throw an error instead
 
   if (this.listeners('set').length > 0) {
 
@@ -198,7 +295,9 @@ Characteristic.prototype.setValue = function(newValue, callback, context, connec
 }
 
 Characteristic.prototype.updateValue = function(newValue, callback, context) {
-
+  if (!this.validateValue(newValue))
+    return; //Need to throw an error instead
+  
   if (newValue === undefined || newValue === null)
     newValue = this.getDefaultValue();
     // no one is listening to the 'set' event, so just assign the value blindly

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -44,6 +44,10 @@ function Service(displayName, UUID, subtype) {
   this.characteristics = [];
   this.optionalCharacteristics = [];
 
+  this.isHiddenService = false;
+  this.isPrimaryService = false;
+  this.linkedServices = [];
+
   // every service has an optional Characteristic.Name property - we'll set it to our displayName
   // if one was given
   // if you don't provide a display name, some HomeKit apps may choose to hide the device.
@@ -83,6 +87,27 @@ Service.prototype.addCharacteristic = function(characteristic) {
   this.emit('service-configurationChange', clone({service:this}));
 
   return characteristic;
+}
+
+//Defines this service as hidden
+Service.prototype.setHiddenService = function (isHidden) {
+    this.isHiddenService = isHidden;
+    this.emit('service-configurationChange', clone({ service: this }));
+}
+
+//Allows setting other services that link to this one.
+Service.prototype.addLinkedService = function (newLinkedService) {
+    //TODO: Add a check if the service is on the same accessory.
+    if (!this.linkedServices.includes(newLinkedService))
+        this.linkedServices.push(newLinkedService);
+    this.emit('service-configurationChange', clone({ service: this }));
+}
+
+Service.prototype.removeLinkedService = function (oldLinkedService) {
+    //TODO: Add a check if the service is on the same accessory.
+    if (!this.linkedServices.includes(newLinkedService))
+        this.linkedServices.splice(this.linkedServices.indexOf(newLinkedService),1);
+    this.emit('service-configurationChange', clone({ service: this }));
 }
 
 Service.prototype.removeCharacteristic = function(characteristic) {
@@ -209,7 +234,19 @@ Service.prototype.toHAP = function(opt) {
   };
 
   if (this.isPrimaryService !== undefined) {
-    hap['primary'] = this.isPrimaryService;
+      hap['primary'] = this.isPrimaryService;
+  }
+
+  if (this.isHiddenService !== undefined) {
+      hap['hidden'] = this.isHiddenService;
+  }
+
+  if (this.linkedServices.length > 0) {
+      hap['linked'] = [];
+      for (var index in this.linkedServices) {
+          var otherService = this.linkedServices[index];
+          hap['linked'].push(otherService.iid);
+      }
   }
 
   return hap;

--- a/lib/gen/HomeKitTypes-Bridge.js
+++ b/lib/gen/HomeKitTypes-Bridge.js
@@ -6,6 +6,134 @@ var Characteristic = require('../Characteristic').Characteristic;
 var Service = require('../Service').Service;
 
 /**
+ * 
+ * Removed in IOS 11
+ * 
+ */
+
+/**
+ * Characteristic "App Matching Identifier"
+ */
+
+Characteristic.AppMatchingIdentifier = function() {
+  Characteristic.call(this, 'App Matching Identifier', '000000A4-0000-1000-8000-0026BB765291');
+  this.setProps({
+    format: Characteristic.Formats.TLV8,
+    perms: [Characteristic.Perms.READ]
+  });
+  this.value = this.getDefaultValue();
+};
+
+inherits(Characteristic.AppMatchingIdentifier, Characteristic);
+
+Characteristic.AppMatchingIdentifier.UUID = '000000A4-0000-1000-8000-0026BB765291';
+
+/**
+ * Characteristic "Programmable Switch Output State"
+ */
+
+Characteristic.ProgrammableSwitchOutputState = function() {
+  Characteristic.call(this, 'Programmable Switch Output State', '00000074-0000-1000-8000-0026BB765291');
+  this.setProps({
+    format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    minStep: 1,
+    perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
+  });
+  this.value = this.getDefaultValue();
+};
+
+inherits(Characteristic.ProgrammableSwitchOutputState, Characteristic);
+
+Characteristic.ProgrammableSwitchOutputState.UUID = '00000074-0000-1000-8000-0026BB765291';
+
+/**
+ * Characteristic "Software Revision"
+ */
+
+Characteristic.SoftwareRevision = function() {
+  Characteristic.call(this, 'Software Revision', '00000054-0000-1000-8000-0026BB765291');
+  this.setProps({
+    format: Characteristic.Formats.STRING,
+    perms: [Characteristic.Perms.READ]
+  });
+  this.value = this.getDefaultValue();
+};
+
+inherits(Characteristic.SoftwareRevision, Characteristic);
+
+Characteristic.SoftwareRevision.UUID = '00000054-0000-1000-8000-0026BB765291';
+
+/**
+ * Service "Camera Control"
+ */
+
+Service.CameraControl = function(displayName, subtype) {
+  Service.call(this, displayName, '00000111-0000-1000-8000-0026BB765291', subtype);
+
+  // Required Characteristics
+  this.addCharacteristic(Characteristic.On);
+
+  // Optional Characteristics
+  this.addOptionalCharacteristic(Characteristic.CurrentHorizontalTiltAngle);
+  this.addOptionalCharacteristic(Characteristic.CurrentVerticalTiltAngle);
+  this.addOptionalCharacteristic(Characteristic.TargetHorizontalTiltAngle);
+  this.addOptionalCharacteristic(Characteristic.TargetVerticalTiltAngle);
+  this.addOptionalCharacteristic(Characteristic.NightVision);
+  this.addOptionalCharacteristic(Characteristic.OpticalZoom);
+  this.addOptionalCharacteristic(Characteristic.DigitalZoom);
+  this.addOptionalCharacteristic(Characteristic.ImageRotation);
+  this.addOptionalCharacteristic(Characteristic.ImageMirroring);
+  this.addOptionalCharacteristic(Characteristic.Name);
+};
+
+inherits(Service.CameraControl, Service);
+
+Service.CameraControl.UUID = '00000111-0000-1000-8000-0026BB765291';
+
+/**
+ * Service "Stateful Programmable Switch"
+ */
+
+Service.StatefulProgrammableSwitch = function(displayName, subtype) {
+  Service.call(this, displayName, '00000088-0000-1000-8000-0026BB765291', subtype);
+
+  // Required Characteristics
+  this.addCharacteristic(Characteristic.ProgrammableSwitchEvent);
+  this.addCharacteristic(Characteristic.ProgrammableSwitchOutputState);
+
+  // Optional Characteristics
+  this.addOptionalCharacteristic(Characteristic.Name);
+};
+
+inherits(Service.StatefulProgrammableSwitch, Service);
+
+Service.StatefulProgrammableSwitch.UUID = '00000088-0000-1000-8000-0026BB765291';
+
+
+// Aliases
+Characteristic.SelectedStreamConfiguration = Characteristic.SelectedRTPStreamConfiguration;
+Service.Label = Service.ServiceLabel;
+Characteristic.LabelNamespace = Characteristic.ServiceLabelNamespace;
+Characteristic.LabelIndex = Characteristic.ServiceLabelIndex;
+
+//Renamed Enums:
+Characteristic.TargetHumidifierDehumidifierState.AUTO = 0; //Is Now HUMIDIFIER_OR_DEHUMIDIFIER
+
+
+
+
+
+
+
+/**
+ * 
+ * Removed in IOS 10
+ * 
+ */
+
+/**
  * Characteristic "Accessory Identifier"
  */
 

--- a/lib/gen/HomeKitTypes.js
+++ b/lib/gen/HomeKitTypes.js
@@ -30,6 +30,9 @@ Characteristic.Active = function() {
   Characteristic.call(this, 'Active', '000000B0-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -88,6 +91,9 @@ Characteristic.AirParticulateSize = function() {
   Characteristic.call(this, 'Air Particulate Size', '00000065-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -109,6 +115,9 @@ Characteristic.AirQuality = function() {
   Characteristic.call(this, 'Air Quality', '00000095-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 5,
+    minValue: 0,
+    validValues: [0,1,2,3,4,5],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -150,11 +159,11 @@ Characteristic.AudioFeedback.UUID = '00000005-0000-1000-8000-0026BB765291';
 Characteristic.BatteryLevel = function() {
   Characteristic.call(this, 'Battery Level', '00000068-0000-1000-8000-0026BB765291');
   this.setProps({
-    format: Characteristic.Formats.UINT8,
+    format: Characteristic.Formats.FLOAT,
     unit: Characteristic.Units.PERCENTAGE,
     maxValue: 100,
     minValue: 0,
-    minStep: 1,
+    minStep: 0.1,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -193,6 +202,9 @@ Characteristic.CarbonDioxideDetected = function() {
   Characteristic.call(this, 'Carbon Dioxide Detected', '00000092-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -216,7 +228,6 @@ Characteristic.CarbonDioxideLevel = function() {
     format: Characteristic.Formats.FLOAT,
     maxValue: 100000,
     minValue: 0,
-    minStep: 100,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -236,7 +247,6 @@ Characteristic.CarbonDioxidePeakLevel = function() {
     format: Characteristic.Formats.FLOAT,
     maxValue: 100000,
     minValue: 0,
-    minStep: 100,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -254,6 +264,9 @@ Characteristic.CarbonMonoxideDetected = function() {
   Characteristic.call(this, 'Carbon Monoxide Detected', '00000069-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -277,7 +290,6 @@ Characteristic.CarbonMonoxideLevel = function() {
     format: Characteristic.Formats.FLOAT,
     maxValue: 100,
     minValue: 0,
-    minStep: 0.1,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -297,7 +309,6 @@ Characteristic.CarbonMonoxidePeakLevel = function() {
     format: Characteristic.Formats.FLOAT,
     maxValue: 100,
     minValue: 0,
-    minStep: 0.1,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -315,6 +326,9 @@ Characteristic.ChargingState = function() {
   Characteristic.call(this, 'Charging State', '0000008F-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 2,
+    minValue: 0,
+    validValues: [0,1,2],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -357,6 +371,9 @@ Characteristic.ContactSensorState = function() {
   Characteristic.call(this, 'Contact Sensor State', '0000006A-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -399,6 +416,9 @@ Characteristic.CurrentAirPurifierState = function() {
   Characteristic.call(this, 'Current Air Purifier State', '000000A9-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 2,
+    minValue: 0,
+    validValues: [0,1,2],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -424,7 +444,6 @@ Characteristic.CurrentAmbientLightLevel = function() {
     unit: Characteristic.Units.LUX,
     maxValue: 100000,
     minValue: 0.0001,
-    minStep: 0.0001,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -442,6 +461,9 @@ Characteristic.CurrentDoorState = function() {
   Characteristic.call(this, 'Current Door State', '0000000E-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 4,
+    minValue: 0,
+    validValues: [0,1,2,3,4],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -466,6 +488,9 @@ Characteristic.CurrentFanState = function() {
   Characteristic.call(this, 'Current Fan State', '000000AF-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 2,
+    minValue: 0,
+    validValues: [0,1,2],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -488,6 +513,9 @@ Characteristic.CurrentHeaterCoolerState = function() {
   Characteristic.call(this, 'Current Heater Cooler State', '000000B1-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 3,
+    minValue: 0,
+    validValues: [0,1,2,3],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -511,6 +539,9 @@ Characteristic.CurrentHeatingCoolingState = function() {
   Characteristic.call(this, 'Current Heating Cooling State', '0000000F-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 2,
+    minValue: 0,
+    validValues: [0,1,2],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -554,6 +585,9 @@ Characteristic.CurrentHumidifierDehumidifierState = function() {
   Characteristic.call(this, 'Current Humidifier Dehumidifier State', '000000B3-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 3,
+    minValue: 0,
+    validValues: [0,1,2,3],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -619,6 +653,9 @@ Characteristic.CurrentSlatState = function() {
   Characteristic.call(this, 'Current Slat State', '000000AA-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 2,
+    minValue: 0,
+    validValues: [0,1,2],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -721,6 +758,9 @@ Characteristic.FilterChangeIndication = function() {
   Characteristic.call(this, 'Filter Change Indication', '000000AC-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -909,6 +949,9 @@ Characteristic.LeakDetected = function() {
   Characteristic.call(this, 'Leak Detected', '00000070-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -947,6 +990,9 @@ Characteristic.LockCurrentState = function() {
   Characteristic.call(this, 'Lock Current State', '0000001D-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 3,
+    minValue: 0,
+    validValues: [0,1,2,3],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -970,6 +1016,9 @@ Characteristic.LockLastKnownAction = function() {
   Characteristic.call(this, 'Lock Last Known Action', '0000001C-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 8,
+    minValue: 0,
+    validValues: [0,1,2,3,4,5,6,7,8],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -999,9 +1048,6 @@ Characteristic.LockManagementAutoSecurityTimeout = function() {
   this.setProps({
     format: Characteristic.Formats.UINT32,
     unit: Characteristic.Units.SECONDS,
-    maxValue: 86400,
-    minValue: 0,
-    minStep: 1,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1019,6 +1065,9 @@ Characteristic.LockPhysicalControls = function() {
   Characteristic.call(this, 'Lock Physical Controls', '000000A7-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1040,6 +1089,9 @@ Characteristic.LockTargetState = function() {
   Characteristic.call(this, 'Lock Target State', '0000001E-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1105,23 +1157,6 @@ inherits(Characteristic.Model, Characteristic);
 Characteristic.Model.UUID = '00000021-0000-1000-8000-0026BB765291';
 
 /**
- * Characteristic "Mute"
- */
-
-Characteristic.Mute = function() {
-  Characteristic.call(this, 'Mute', '0000011A-0000-1000-8000-0026BB765291');
-  this.setProps({
-    format: Characteristic.Formats.BOOL,
-    perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
-  });
-  this.value = this.getDefaultValue();
-};
-
-inherits(Characteristic.Mute, Characteristic);
-
-Characteristic.Mute.UUID = '0000011A-0000-1000-8000-0026BB765291';
-
-/**
  * Characteristic "Motion Detected"
  */
 
@@ -1137,6 +1172,23 @@ Characteristic.MotionDetected = function() {
 inherits(Characteristic.MotionDetected, Characteristic);
 
 Characteristic.MotionDetected.UUID = '00000022-0000-1000-8000-0026BB765291';
+
+/**
+ * Characteristic "Mute"
+ */
+
+Characteristic.Mute = function() {
+  Characteristic.call(this, 'Mute', '0000011A-0000-1000-8000-0026BB765291');
+  this.setProps({
+    format: Characteristic.Formats.BOOL,
+    perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
+  });
+  this.value = this.getDefaultValue();
+};
+
+inherits(Characteristic.Mute, Characteristic);
+
+Characteristic.Mute.UUID = '0000011A-0000-1000-8000-0026BB765291';
 
 /**
  * Characteristic "Name"
@@ -1217,6 +1269,9 @@ Characteristic.OccupancyDetected = function() {
   Characteristic.call(this, 'Occupancy Detected', '00000071-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1417,6 +1472,9 @@ Characteristic.PositionState = function() {
   Characteristic.call(this, 'Position State', '00000072-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 2,
+    minValue: 0,
+    validValues: [0,1,2],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1439,9 +1497,11 @@ Characteristic.ProgrammableSwitchEvent = function() {
   Characteristic.call(this, 'Programmable Switch Event', '00000073-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 2,
+    minValue: 0,
+    validValues: [0,1,2],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
-  this.eventOnlyCharacteristic = true;
   this.value = this.getDefaultValue();
 };
 
@@ -1522,6 +1582,9 @@ Characteristic.RotationDirection = function() {
   Characteristic.call(this, 'Rotation Direction', '00000028-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.INT,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1605,6 +1668,9 @@ Characteristic.SecuritySystemCurrentState = function() {
   Characteristic.call(this, 'Security System Current State', '00000066-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 4,
+    minValue: 0,
+    validValues: [0,1,2,3,4],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1629,6 +1695,9 @@ Characteristic.SecuritySystemTargetState = function() {
   Characteristic.call(this, 'Security System Target State', '00000067-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 3,
+    minValue: 0,
+    validValues: [0,1,2,3],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1706,6 +1775,9 @@ Characteristic.ServiceLabelNamespace = function() {
   Characteristic.call(this, 'Service Label Namespace', '000000CD-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ]
   });
   this.value = this.getDefaultValue();
@@ -1727,7 +1799,7 @@ Characteristic.SetupEndpoints = function() {
   Characteristic.call(this, 'Setup Endpoints', '00000118-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.TLV8,
-    perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
+    perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE]
   });
   this.value = this.getDefaultValue();
 };
@@ -1744,7 +1816,10 @@ Characteristic.SlatType = function() {
   Characteristic.call(this, 'Slat Type', '000000C0-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
-    perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
+    perms: [Characteristic.Perms.READ]
   });
   this.value = this.getDefaultValue();
 };
@@ -1765,6 +1840,9 @@ Characteristic.SmokeDetected = function() {
   Characteristic.call(this, 'Smoke Detected', '00000076-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1803,6 +1881,9 @@ Characteristic.StatusFault = function() {
   Characteristic.call(this, 'Status Fault', '00000077-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1824,6 +1905,9 @@ Characteristic.StatusJammed = function() {
   Characteristic.call(this, 'Status Jammed', '00000078-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1845,6 +1929,9 @@ Characteristic.StatusLowBattery = function() {
   Characteristic.call(this, 'Status Low Battery', '00000079-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1866,6 +1953,9 @@ Characteristic.StatusTampered = function() {
   Characteristic.call(this, 'Status Tampered', '0000007A-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1887,7 +1977,7 @@ Characteristic.StreamingStatus = function() {
   Characteristic.call(this, 'Streaming Status', '00000120-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.TLV8,
-    perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
+    perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY] //Manual Fix for Permisions
   });
   this.value = this.getDefaultValue();
 };
@@ -1975,6 +2065,9 @@ Characteristic.SwingMode = function() {
   Characteristic.call(this, 'Swing Mode', '000000B6-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -1996,6 +2089,9 @@ Characteristic.TargetAirPurifierState = function() {
   Characteristic.call(this, 'Target Air Purifier State', '000000A8-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -2017,6 +2113,9 @@ Characteristic.TargetAirQuality = function() {
   Characteristic.call(this, 'Target Air Quality', '000000AE-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 2,
+    minValue: 0,
+    validValues: [0,1,2],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -2039,6 +2138,9 @@ Characteristic.TargetDoorState = function() {
   Characteristic.call(this, 'Target Door State', '00000032-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -2060,6 +2162,9 @@ Characteristic.TargetFanState = function() {
   Characteristic.call(this, 'Target Fan State', '000000BF-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -2081,6 +2186,9 @@ Characteristic.TargetHeaterCoolerState = function() {
   Characteristic.call(this, 'Target Heater Cooler State', '000000B2-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 2,
+    minValue: 0,
+    validValues: [0,1,2],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -2103,6 +2211,9 @@ Characteristic.TargetHeatingCoolingState = function() {
   Characteristic.call(this, 'Target Heating Cooling State', '00000033-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 3,
+    minValue: 0,
+    validValues: [0,1,2,3],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -2147,6 +2258,9 @@ Characteristic.TargetHumidifierDehumidifierState = function() {
   Characteristic.call(this, 'Target Humidifier Dehumidifier State', '000000B4-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 2,
+    minValue: 0,
+    validValues: [0,1,2],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -2157,7 +2271,7 @@ inherits(Characteristic.TargetHumidifierDehumidifierState, Characteristic);
 Characteristic.TargetHumidifierDehumidifierState.UUID = '000000B4-0000-1000-8000-0026BB765291';
 
 // The value property of TargetHumidifierDehumidifierState must be one of the following:
-Characteristic.TargetHumidifierDehumidifierState.AUTO = 0;
+Characteristic.TargetHumidifierDehumidifierState.HUMIDIFIER_OR_DEHUMIDIFIER = 0;
 Characteristic.TargetHumidifierDehumidifierState.HUMIDIFIER = 1;
 Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER = 2;
 
@@ -2211,6 +2325,9 @@ Characteristic.TargetSlatState = function() {
   Characteristic.call(this, 'Target Slat State', '000000BE-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -2295,6 +2412,9 @@ Characteristic.TemperatureDisplayUnits = function() {
   Characteristic.call(this, 'Temperature Display Units', '00000036-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
+    maxValue: 1,
+    minValue: 0,
+    validValues: [0,1],
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -2834,11 +2954,11 @@ Service.Lightbulb = function(displayName, subtype) {
   this.addCharacteristic(Characteristic.On);
 
   // Optional Characteristics
-  this.addOptionalCharacteristic(Characteristic.ColorTemperature);
   this.addOptionalCharacteristic(Characteristic.Brightness);
   this.addOptionalCharacteristic(Characteristic.Hue);
   this.addOptionalCharacteristic(Characteristic.Saturation);
   this.addOptionalCharacteristic(Characteristic.Name);
+  this.addOptionalCharacteristic(Characteristic.ColorTemperature); //Manual fix to add temperature
 };
 
 inherits(Service.Lightbulb, Service);

--- a/lib/gen/HomeKitTypes.js
+++ b/lib/gen/HomeKitTypes.js
@@ -1441,6 +1441,7 @@ Characteristic.ProgrammableSwitchEvent = function() {
     format: Characteristic.Formats.UINT8,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
+  this.eventOnlyCharacteristic = true;
   this.value = this.getDefaultValue();
 };
 
@@ -2833,6 +2834,7 @@ Service.Lightbulb = function(displayName, subtype) {
   this.addCharacteristic(Characteristic.On);
 
   // Optional Characteristics
+  this.addOptionalCharacteristic(Characteristic.ColorTemperature);
   this.addOptionalCharacteristic(Characteristic.Brightness);
   this.addOptionalCharacteristic(Characteristic.Hue);
   this.addOptionalCharacteristic(Characteristic.Saturation);

--- a/lib/gen/HomeKitTypes.js
+++ b/lib/gen/HomeKitTypes.js
@@ -6,47 +6,6 @@ var Characteristic = require('../Characteristic').Characteristic;
 var Service = require('../Service').Service;
 
 /**
- * Characteristic "Label Namespace"
- */
-
-Characteristic.LabelNamespace = function() {
-  Characteristic.call(this, 'Label Namespace', '000000CD-0000-1000-8000-0026BB765291');
-  this.setProps({
-    format: Characteristic.Formats.UINT8,
-    perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
-  });
-  this.value = this.getDefaultValue();
-};
-
-inherits(Characteristic.LabelNamespace, Characteristic);
-
-Characteristic.LabelNamespace.UUID = '000000CD-0000-1000-8000-0026BB765291';
-
-// The value property of LabelNamespace must be one of the following:
-Characteristic.LabelNamespace.DOT = 0;
-Characteristic.LabelNamespace.NUMBER = 1;
-
-/**
- * Characteristic "Label Index"
- */
-
-Characteristic.LabelIndex = function() {
-  Characteristic.call(this, 'Label Index', '000000CB-0000-1000-8000-0026BB765291');
-  this.setProps({
-    format: Characteristic.Formats.UINT8,
-    maxValue: 255,
-    minValue: 1,
-    minStep: 1,
-    perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
-  });
-  this.value = this.getDefaultValue();
-};
-
-inherits(Characteristic.LabelIndex, Characteristic);
-
-Characteristic.LabelIndex.UUID = '000000CB-0000-1000-8000-0026BB765291';
-
-/**
  * Characteristic "Accessory Flags"
  */
 
@@ -166,23 +125,6 @@ Characteristic.AirQuality.GOOD = 2;
 Characteristic.AirQuality.FAIR = 3;
 Characteristic.AirQuality.INFERIOR = 4;
 Characteristic.AirQuality.POOR = 5;
-
-/**
- * Characteristic "App Matching Identifier"
- */
-
-Characteristic.AppMatchingIdentifier = function() {
-  Characteristic.call(this, 'App Matching Identifier', '000000A4-0000-1000-8000-0026BB765291');
-  this.setProps({
-    format: Characteristic.Formats.TLV8,
-    perms: [Characteristic.Perms.READ]
-  });
-  this.value = this.getDefaultValue();
-};
-
-inherits(Characteristic.AppMatchingIdentifier, Characteristic);
-
-Characteristic.AppMatchingIdentifier.UUID = '000000A4-0000-1000-8000-0026BB765291';
 
 /**
  * Characteristic "Audio Feedback"
@@ -373,7 +315,6 @@ Characteristic.ChargingState = function() {
   Characteristic.call(this, 'Charging State', '0000008F-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
-    maxValue: 2,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
@@ -387,6 +328,26 @@ Characteristic.ChargingState.UUID = '0000008F-0000-1000-8000-0026BB765291';
 Characteristic.ChargingState.NOT_CHARGING = 0;
 Characteristic.ChargingState.CHARGING = 1;
 Characteristic.ChargingState.NOT_CHARGEABLE = 2;
+
+/**
+ * Characteristic "Color Temperature"
+ */
+
+Characteristic.ColorTemperature = function() {
+  Characteristic.call(this, 'Color Temperature', '000000CE-0000-1000-8000-0026BB765291');
+  this.setProps({
+    format: Characteristic.Formats.UINT32,
+    maxValue: 500,
+    minValue: 140,
+    minStep: 1,
+    perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
+  });
+  this.value = this.getDefaultValue();
+};
+
+inherits(Characteristic.ColorTemperature, Characteristic);
+
+Characteristic.ColorTemperature.UUID = '000000CE-0000-1000-8000-0026BB765291';
 
 /**
  * Characteristic "Contact Sensor State"
@@ -1478,12 +1439,8 @@ Characteristic.ProgrammableSwitchEvent = function() {
   Characteristic.call(this, 'Programmable Switch Event', '00000073-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.UINT8,
-    maxValue: 2,
-    minValue: 0,
-    minStep: 1,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });
-  this.eventOnlyCharacteristic = true;
   this.value = this.getDefaultValue();
 };
 
@@ -1495,26 +1452,6 @@ Characteristic.ProgrammableSwitchEvent.UUID = '00000073-0000-1000-8000-0026BB765
 Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS = 0;
 Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS = 1;
 Characteristic.ProgrammableSwitchEvent.LONG_PRESS = 2;
-
-/**
- * Characteristic "Programmable Switch Output State"
- */
-
-Characteristic.ProgrammableSwitchOutputState = function() {
-  Characteristic.call(this, 'Programmable Switch Output State', '00000074-0000-1000-8000-0026BB765291');
-  this.setProps({
-    format: Characteristic.Formats.UINT8,
-    maxValue: 1,
-    minValue: 0,
-    minStep: 1,
-    perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
-  });
-  this.value = this.getDefaultValue();
-};
-
-inherits(Characteristic.ProgrammableSwitchOutputState, Characteristic);
-
-Characteristic.ProgrammableSwitchOutputState.UUID = '00000074-0000-1000-8000-0026BB765291';
 
 /**
  * Characteristic "Relative Humidity Dehumidifier Threshold"
@@ -1707,11 +1644,11 @@ Characteristic.SecuritySystemTargetState.NIGHT_ARM = 2;
 Characteristic.SecuritySystemTargetState.DISARM = 3;
 
 /**
- * Characteristic "Selected Stream Configuration"
+ * Characteristic "Selected RTP Stream Configuration"
  */
 
-Characteristic.SelectedStreamConfiguration = function() {
-  Characteristic.call(this, 'Selected Stream Configuration', '00000117-0000-1000-8000-0026BB765291');
+Characteristic.SelectedRTPStreamConfiguration = function() {
+  Characteristic.call(this, 'Selected RTP Stream Configuration', '00000117-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.TLV8,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE]
@@ -1719,9 +1656,9 @@ Characteristic.SelectedStreamConfiguration = function() {
   this.value = this.getDefaultValue();
 };
 
-inherits(Characteristic.SelectedStreamConfiguration, Characteristic);
+inherits(Characteristic.SelectedRTPStreamConfiguration, Characteristic);
 
-Characteristic.SelectedStreamConfiguration.UUID = '00000117-0000-1000-8000-0026BB765291';
+Characteristic.SelectedRTPStreamConfiguration.UUID = '00000117-0000-1000-8000-0026BB765291';
 
 /**
  * Characteristic "Serial Number"
@@ -1739,6 +1676,47 @@ Characteristic.SerialNumber = function() {
 inherits(Characteristic.SerialNumber, Characteristic);
 
 Characteristic.SerialNumber.UUID = '00000030-0000-1000-8000-0026BB765291';
+
+/**
+ * Characteristic "Service Label Index"
+ */
+
+Characteristic.ServiceLabelIndex = function() {
+  Characteristic.call(this, 'Service Label Index', '000000CB-0000-1000-8000-0026BB765291');
+  this.setProps({
+    format: Characteristic.Formats.UINT8,
+    maxValue: 255,
+    minValue: 1,
+    minStep: 1,
+    perms: [Characteristic.Perms.READ]
+  });
+  this.value = this.getDefaultValue();
+};
+
+inherits(Characteristic.ServiceLabelIndex, Characteristic);
+
+Characteristic.ServiceLabelIndex.UUID = '000000CB-0000-1000-8000-0026BB765291';
+
+/**
+ * Characteristic "Service Label Namespace"
+ */
+
+Characteristic.ServiceLabelNamespace = function() {
+  Characteristic.call(this, 'Service Label Namespace', '000000CD-0000-1000-8000-0026BB765291');
+  this.setProps({
+    format: Characteristic.Formats.UINT8,
+    perms: [Characteristic.Perms.READ]
+  });
+  this.value = this.getDefaultValue();
+};
+
+inherits(Characteristic.ServiceLabelNamespace, Characteristic);
+
+Characteristic.ServiceLabelNamespace.UUID = '000000CD-0000-1000-8000-0026BB765291';
+
+// The value property of ServiceLabelNamespace must be one of the following:
+Characteristic.ServiceLabelNamespace.DOTS = 0;
+Characteristic.ServiceLabelNamespace.ARABIC_NUMERALS = 1;
 
 /**
  * Characteristic "Setup Endpoints"
@@ -1798,23 +1776,6 @@ Characteristic.SmokeDetected.UUID = '00000076-0000-1000-8000-0026BB765291';
 // The value property of SmokeDetected must be one of the following:
 Characteristic.SmokeDetected.SMOKE_NOT_DETECTED = 0;
 Characteristic.SmokeDetected.SMOKE_DETECTED = 1;
-
-/**
- * Characteristic "Software Revision"
- */
-
-Characteristic.SoftwareRevision = function() {
-  Characteristic.call(this, 'Software Revision', '00000054-0000-1000-8000-0026BB765291');
-  this.setProps({
-    format: Characteristic.Formats.STRING,
-    perms: [Characteristic.Perms.READ]
-  });
-  this.value = this.getDefaultValue();
-};
-
-inherits(Characteristic.SoftwareRevision, Characteristic);
-
-Characteristic.SoftwareRevision.UUID = '00000054-0000-1000-8000-0026BB765291';
 
 /**
  * Characteristic "Status Active"
@@ -1925,7 +1886,7 @@ Characteristic.StreamingStatus = function() {
   Characteristic.call(this, 'Streaming Status', '00000120-0000-1000-8000-0026BB765291');
   this.setProps({
     format: Characteristic.Formats.TLV8,
-    perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+    perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
   });
   this.value = this.getDefaultValue();
 };
@@ -2390,7 +2351,7 @@ Characteristic.VOCDensity.UUID = '000000C8-0000-1000-8000-0026BB765291';
 Characteristic.Volume = function() {
   Characteristic.call(this, 'Volume', '00000119-0000-1000-8000-0026BB765291');
   this.setProps({
-    format: Characteristic.Formats.FLOAT,
+    format: Characteristic.Formats.UINT8,
     unit: Characteristic.Units.PERCENTAGE,
     maxValue: 100,
     minValue: 0,
@@ -2424,21 +2385,6 @@ inherits(Characteristic.WaterLevel, Characteristic);
 Characteristic.WaterLevel.UUID = '000000B5-0000-1000-8000-0026BB765291';
 
 /**
- * Service "Label"
- */
-
-Service.Label = function(displayName, subtype) {
-  Service.call(this, displayName, '000000CC-0000-1000-8000-0026BB765291', subtype);
-
-  // Required Characteristics
-  this.addCharacteristic(Characteristic.LabelNamespace);
-};
-
-inherits(Service.Label, Service);
-
-Service.Label.UUID = '000000CC-0000-1000-8000-0026BB765291';
-
-/**
  * Service "Accessory Information"
  */
 
@@ -2451,13 +2397,11 @@ Service.AccessoryInformation = function(displayName, subtype) {
   this.addCharacteristic(Characteristic.Model);
   this.addCharacteristic(Characteristic.Name);
   this.addCharacteristic(Characteristic.SerialNumber);
+  this.addCharacteristic(Characteristic.FirmwareRevision);
 
   // Optional Characteristics
-  this.addOptionalCharacteristic(Characteristic.FirmwareRevision);
   this.addOptionalCharacteristic(Characteristic.HardwareRevision);
-  this.addOptionalCharacteristic(Characteristic.SoftwareRevision);
   this.addOptionalCharacteristic(Characteristic.AccessoryFlags);
-  this.addOptionalCharacteristic(Characteristic.AppMatchingIdentifier);
 };
 
 inherits(Service.AccessoryInformation, Service);
@@ -2538,33 +2482,6 @@ inherits(Service.BatteryService, Service);
 Service.BatteryService.UUID = '00000096-0000-1000-8000-0026BB765291';
 
 /**
- * Service "Camera Control"
- */
-
-Service.CameraControl = function(displayName, subtype) {
-  Service.call(this, displayName, '00000111-0000-1000-8000-0026BB765291', subtype);
-
-  // Required Characteristics
-  this.addCharacteristic(Characteristic.On);
-
-  // Optional Characteristics
-  this.addOptionalCharacteristic(Characteristic.CurrentHorizontalTiltAngle);
-  this.addOptionalCharacteristic(Characteristic.CurrentVerticalTiltAngle);
-  this.addOptionalCharacteristic(Characteristic.TargetHorizontalTiltAngle);
-  this.addOptionalCharacteristic(Characteristic.TargetVerticalTiltAngle);
-  this.addOptionalCharacteristic(Characteristic.NightVision);
-  this.addOptionalCharacteristic(Characteristic.OpticalZoom);
-  this.addOptionalCharacteristic(Characteristic.DigitalZoom);
-  this.addOptionalCharacteristic(Characteristic.ImageRotation);
-  this.addOptionalCharacteristic(Characteristic.ImageMirroring);
-  this.addOptionalCharacteristic(Characteristic.Name);
-};
-
-inherits(Service.CameraControl, Service);
-
-Service.CameraControl.UUID = '00000111-0000-1000-8000-0026BB765291';
-
-/**
  * Service "Camera RTP Stream Management"
  */
 
@@ -2575,7 +2492,7 @@ Service.CameraRTPStreamManagement = function(displayName, subtype) {
   this.addCharacteristic(Characteristic.SupportedVideoStreamConfiguration);
   this.addCharacteristic(Characteristic.SupportedAudioStreamConfiguration);
   this.addCharacteristic(Characteristic.SupportedRTPConfiguration);
-  this.addCharacteristic(Characteristic.SelectedStreamConfiguration);
+  this.addCharacteristic(Characteristic.SelectedRTPStreamConfiguration);
   this.addCharacteristic(Characteristic.StreamingStatus);
   this.addCharacteristic(Characteristic.SetupEndpoints);
 
@@ -3076,6 +2993,24 @@ inherits(Service.SecuritySystem, Service);
 Service.SecuritySystem.UUID = '0000007E-0000-1000-8000-0026BB765291';
 
 /**
+ * Service "Service Label"
+ */
+
+Service.ServiceLabel = function(displayName, subtype) {
+  Service.call(this, displayName, '000000CC-0000-1000-8000-0026BB765291', subtype);
+
+  // Required Characteristics
+  this.addCharacteristic(Characteristic.ServiceLabelNamespace);
+
+  // Optional Characteristics
+  this.addOptionalCharacteristic(Characteristic.Name);
+};
+
+inherits(Service.ServiceLabel, Service);
+
+Service.ServiceLabel.UUID = '000000CC-0000-1000-8000-0026BB765291';
+
+/**
  * Service "Slat"
  */
 
@@ -3139,25 +3074,6 @@ inherits(Service.Speaker, Service);
 Service.Speaker.UUID = '00000113-0000-1000-8000-0026BB765291';
 
 /**
- * Service "Stateful Programmable Switch"
- */
-
-Service.StatefulProgrammableSwitch = function(displayName, subtype) {
-  Service.call(this, displayName, '00000088-0000-1000-8000-0026BB765291', subtype);
-
-  // Required Characteristics
-  this.addCharacteristic(Characteristic.ProgrammableSwitchEvent);
-  this.addCharacteristic(Characteristic.ProgrammableSwitchOutputState);
-
-  // Optional Characteristics
-  this.addOptionalCharacteristic(Characteristic.Name);
-};
-
-inherits(Service.StatefulProgrammableSwitch, Service);
-
-Service.StatefulProgrammableSwitch.UUID = '00000088-0000-1000-8000-0026BB765291';
-
-/**
  * Service "Stateless Programmable Switch"
  */
 
@@ -3169,7 +3085,7 @@ Service.StatelessProgrammableSwitch = function(displayName, subtype) {
 
   // Optional Characteristics
   this.addOptionalCharacteristic(Characteristic.Name);
-  this.addOptionalCharacteristic(Characteristic.LabelIndex);
+  this.addOptionalCharacteristic(Characteristic.ServiceLabelIndex);
 };
 
 inherits(Service.StatelessProgrammableSwitch, Service);
@@ -3291,3 +3207,4 @@ inherits(Service.WindowCovering, Service);
 Service.WindowCovering.UUID = '0000008C-0000-1000-8000-0026BB765291';
 
 var HomeKitTypesBridge = require('./HomeKitTypes-Bridge');
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hap-nodejs",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "description": "HAP-NodeJS is a Node.js implementation of HomeKit Accessory Server.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
There are many changes in the HomeKit Accessory Simulator metadata. Please review this list and let me know if anything needs to be manually put back:
Camera Related Items:
	Characteristic.SelectedStreamConfiguration renamed to Characteristic.SelectedRTPStreamConfiguration
	Service.CameraControl Removed
	Characteristic.DigitalZoom no longer attached to any service
	Characteristic.ImageMirroring no longer attached to any service
	Characteristic.ImageRotation no longer attached to any service
	Characteristic.NightVision no longer attached to any service
	Characteristic.OpticalZoom no longer attached to any service
	Characteristic.StreamingStatus is now writable
	
Utility Items:
	Service.Label renamed to Service.ServiceLabel
	Characteristic.LabelNamespace renamed to Characteristic.ServiceLabelNamespace
	Characteristic.LabelIndex renamed to Characteristic.ServiceLabelIndex
	Characteristic.AppMatchingIdentifier removed
	Characteristic.ProgrammableSwitchOutputState removed
	Characteristic.SoftwareRevision removed
	Service.StatefulProgrammableSwitch removed
	Service.AccessoryInformation now has Characteristic.FirmwareRevision as Required
	Service.AccessoryInformation no longer has Characteristic.SoftwareRevision as an associated Characteristic
	Service.AccessoryInformation no longer has Characteristic.AppMatchingIdentifier as an associated Characteristic

Other Changes:
	Characteristic.VOCDensity changed from FLOAT to UINT8
	Characteristic.ProgrammableSwitchEvent can now have any UINT8 value.
	Characteristic.ChargingState no longer has a maximum value of 2, but the Enumeration for it still only has up to 2 items.
	
Added Items:
	Characteristic.ColorTemperature

Manual Changes I've made:
	Associated Characteristic.ColorTemperature as an optional characteristic of the Light Bulb.
