### PR TITLE
Allow any characteristic to auto-add to a service when getting it.

### DIFF
--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -381,10 +381,11 @@ Accessory.prototype._assignIDs = function(identifierCache) {
 
   for (var index in this.services) {
     var service = this.services[index];
-    if (this._isBridge)
-      service._assignIDs(identifierCache, this.UUID, 3000111222);
-    else
+    if (this._isBridge) {
+      service._assignIDs(identifierCache, this.UUID, 2000000000);
+    } else {
       service._assignIDs(identifierCache, this.UUID);
+    }
   }
 
   // now assign IDs for any Accessories we are bridging

--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -381,7 +381,10 @@ Accessory.prototype._assignIDs = function(identifierCache) {
 
   for (var index in this.services) {
     var service = this.services[index];
-    service._assignIDs(identifierCache, this.UUID);
+    if (this._isBridge)
+      service._assignIDs(identifierCache, this.UUID, 3000111222);
+    else
+      service._assignIDs(identifierCache, this.UUID);
   }
 
   // now assign IDs for any Accessories we are bridging

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -63,11 +63,11 @@ function Service(displayName, UUID, subtype) {
 
 inherits(Service, EventEmitter);
 
-Service.prototype.addCharacteristic = function(characteristic) {
+Service.prototype.addCharacteristic = function (characteristic) {
   // characteristic might be a constructor like `Characteristic.Brightness` instead of an instance
   // of Characteristic. Coerce if necessary.
   if (typeof characteristic === 'function') {
-	  characteristic = new (Function.prototype.bind.apply(characteristic, arguments));
+    characteristic = new (Function.prototype.bind.apply(characteristic, arguments));
   }
   // check for UUID conflict
   for (var index in this.characteristics) {
@@ -77,40 +77,40 @@ Service.prototype.addCharacteristic = function(characteristic) {
   }
 
   // listen for changes in characteristics and bubble them up
-  characteristic.on('change', function(change) {
+  characteristic.on('change', function (change) {
     // make a new object with the relevant characteristic added, and bubble it up
-    this.emit('characteristic-change', clone(change, {characteristic:characteristic}));
+    this.emit('characteristic-change', clone(change, { characteristic: characteristic }));
   }.bind(this));
 
   this.characteristics.push(characteristic);
 
-  this.emit('service-configurationChange', clone({service:this}));
+  this.emit('service-configurationChange', clone({ service: this }));
 
   return characteristic;
 }
 
 //Defines this service as hidden
 Service.prototype.setHiddenService = function (isHidden) {
-    this.isHiddenService = isHidden;
-    this.emit('service-configurationChange', clone({ service: this }));
+  this.isHiddenService = isHidden;
+  this.emit('service-configurationChange', clone({ service: this }));
 }
 
 //Allows setting other services that link to this one.
 Service.prototype.addLinkedService = function (newLinkedService) {
-    //TODO: Add a check if the service is on the same accessory.
-    if (!this.linkedServices.includes(newLinkedService))
-        this.linkedServices.push(newLinkedService);
-    this.emit('service-configurationChange', clone({ service: this }));
+  //TODO: Add a check if the service is on the same accessory.
+  if (!this.linkedServices.includes(newLinkedService))
+    this.linkedServices.push(newLinkedService);
+  this.emit('service-configurationChange', clone({ service: this }));
 }
 
 Service.prototype.removeLinkedService = function (oldLinkedService) {
-    //TODO: Add a check if the service is on the same accessory.
-    if (!this.linkedServices.includes(newLinkedService))
-        this.linkedServices.splice(this.linkedServices.indexOf(newLinkedService),1);
-    this.emit('service-configurationChange', clone({ service: this }));
+  //TODO: Add a check if the service is on the same accessory.
+  if (!this.linkedServices.includes(newLinkedService))
+    this.linkedServices.splice(this.linkedServices.indexOf(newLinkedService), 1);
+  this.emit('service-configurationChange', clone({ service: this }));
 }
 
-Service.prototype.removeCharacteristic = function(characteristic) {
+Service.prototype.removeCharacteristic = function (characteristic) {
   var targetCharacteristicIndex;
 
   for (var index in this.characteristics) {
@@ -126,24 +126,24 @@ Service.prototype.removeCharacteristic = function(characteristic) {
     this.characteristics.splice(targetCharacteristicIndex, 1);
     characteristic.removeAllListeners();
 
-    this.emit('service-configurationChange', clone({service:this}));
+    this.emit('service-configurationChange', clone({ service: this }));
   }
 }
 
-Service.prototype.getCharacteristic = function(name) {
-	// returns a characteristic object from the service
-	// If  Service.prototype.getCharacteristic(Characteristic.Type)  does not find the characteristic,
-	// but the type is in optionalCharacteristics, it adds the characteristic.type to the service and returns it.
-	var index, characteristic;
-	for (index in this.characteristics) {
-		characteristic = this.characteristics[index];
-		if (typeof name === 'string' && characteristic.displayName === name) {
-			return characteristic;
-		}
-		else if (typeof name === 'function' && ((characteristic instanceof name) || (name.UUID === characteristic.UUID))) {
-			return characteristic;
-		}
-	}
+Service.prototype.getCharacteristic = function (name) {
+  // returns a characteristic object from the service
+  // If  Service.prototype.getCharacteristic(Characteristic.Type)  does not find the characteristic,
+  // but the type is in optionalCharacteristics, it adds the characteristic.type to the service and returns it.
+  var index, characteristic;
+  for (index in this.characteristics) {
+    characteristic = this.characteristics[index];
+    if (typeof name === 'string' && characteristic.displayName === name) {
+      return characteristic;
+    }
+    else if (typeof name === 'function' && ((characteristic instanceof name) || (name.UUID === characteristic.UUID))) {
+      return characteristic;
+    }
+  }
   if (typeof name === 'function') {
     for (index in this.optionalCharacteristics) {
       characteristic = this.optionalCharacteristics[index];
@@ -159,33 +159,33 @@ Service.prototype.getCharacteristic = function(name) {
   }
 };
 
-Service.prototype.testCharacteristic = function(name) {
-	// checks for the existence of a characteristic object in the service
-	var index, characteristic;
-	for (index in this.characteristics) {
-		characteristic = this.characteristics[index];
-		if (typeof name === 'string' && characteristic.displayName === name) {
-			return true;
-		}
-		else if (typeof name === 'function' && ((characteristic instanceof name) || (name.UUID === characteristic.UUID))) {
-			return true;
-		}
-	}
-	return false;
+Service.prototype.testCharacteristic = function (name) {
+  // checks for the existence of a characteristic object in the service
+  var index, characteristic;
+  for (index in this.characteristics) {
+    characteristic = this.characteristics[index];
+    if (typeof name === 'string' && characteristic.displayName === name) {
+      return true;
+    }
+    else if (typeof name === 'function' && ((characteristic instanceof name) || (name.UUID === characteristic.UUID))) {
+      return true;
+    }
+  }
+  return false;
 }
 
-Service.prototype.setCharacteristic = function(name, value) {
+Service.prototype.setCharacteristic = function (name, value) {
   this.getCharacteristic(name).setValue(value);
   return this; // for chaining
 }
 
 // A function to only updating the remote value, but not firiring the 'set' event.
-Service.prototype.updateCharacteristic = function(name, value){
+Service.prototype.updateCharacteristic = function (name, value) {
   this.getCharacteristic(name).updateValue(value);
   return this;
 }
 
-Service.prototype.addOptionalCharacteristic = function(characteristic) {
+Service.prototype.addOptionalCharacteristic = function (characteristic) {
   // characteristic might be a constructor like `Characteristic.Brightness` instead of an instance
   // of Characteristic. Coerce if necessary.
   if (typeof characteristic === 'function')
@@ -194,7 +194,7 @@ Service.prototype.addOptionalCharacteristic = function(characteristic) {
   this.optionalCharacteristics.push(characteristic);
 }
 
-Service.prototype.getCharacteristicByIID = function(iid) {
+Service.prototype.getCharacteristicByIID = function (iid) {
   for (var index in this.characteristics) {
     var characteristic = this.characteristics[index];
     if (characteristic.iid === iid)
@@ -202,13 +202,13 @@ Service.prototype.getCharacteristicByIID = function(iid) {
   }
 }
 
-Service.prototype._assignIDs = function(identifierCache, accessoryName, baseIID) {
+Service.prototype._assignIDs = function (identifierCache, accessoryName, baseIID) {
   if (baseIID === undefined) {
     baseIID = 0;
   }
   // the Accessory Information service must have a (reserved by IdentifierCache) ID of 1
   if (this.UUID === '0000003E-0000-1000-8000-0026BB765291') {
-      this.iid = 1;
+    this.iid = 1;
   }
   else {
     // assign our own ID based on our UUID
@@ -225,7 +225,7 @@ Service.prototype._assignIDs = function(identifierCache, accessoryName, baseIID)
 /**
  * Returns a JSON representation of this Accessory suitable for delivering to HAP clients.
  */
-Service.prototype.toHAP = function(opt) {
+Service.prototype.toHAP = function (opt) {
 
   var characteristicsHAP = [];
 
@@ -241,33 +241,33 @@ Service.prototype.toHAP = function(opt) {
   };
 
   if (this.isPrimaryService !== undefined) {
-      hap['primary'] = this.isPrimaryService;
+    hap['primary'] = this.isPrimaryService;
   }
 
   if (this.isHiddenService !== undefined) {
-      hap['hidden'] = this.isHiddenService;
+    hap['hidden'] = this.isHiddenService;
   }
 
   if (this.linkedServices.length > 0) {
-      hap['linked'] = [];
-      for (var index in this.linkedServices) {
-          var otherService = this.linkedServices[index];
-          hap['linked'].push(otherService.iid);
-      }
+    hap['linked'] = [];
+    for (var index in this.linkedServices) {
+      var otherService = this.linkedServices[index];
+      hap['linked'].push(otherService.iid);
+    }
   }
 
   return hap;
 }
 
-Service.prototype._setupCharacteristic = function(characteristic) {
+Service.prototype._setupCharacteristic = function (characteristic) {
   // listen for changes in characteristics and bubble them up
-  characteristic.on('change', function(change) {
+  characteristic.on('change', function (change) {
     // make a new object with the relevant characteristic added, and bubble it up
-    this.emit('characteristic-change', clone(change, {characteristic:characteristic}));
+    this.emit('characteristic-change', clone(change, { characteristic: characteristic }));
   }.bind(this));
 }
 
-Service.prototype._sideloadCharacteristics = function(targetCharacteristics) {
+Service.prototype._sideloadCharacteristics = function (targetCharacteristics) {
   for (var index in targetCharacteristics) {
     var target = targetCharacteristics[index];
     this._setupCharacteristic(target);

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -152,6 +152,10 @@ Service.prototype.getCharacteristic = function(name) {
 			}
 		}
 	}
+    //Not found in optional Characteristics. Adding anyway, but warning about it if it isn't the Name.
+    if (name!==Characteristic.Name)
+      console.warn("HAP Warning: Characteristic %s not in required or optional characteristics for service %s. Adding anyway.", name.UUID, this.UUID);
+  return this.addCharacteristic(name);
 };
 
 Service.prototype.testCharacteristic = function(name) {

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -154,8 +154,8 @@ Service.prototype.getCharacteristic = function(name) {
     //Not found in optional Characteristics. Adding anyway, but warning about it if it isn't the Name.
     if (name !== Characteristic.Name) {
       console.warn("HAP Warning: Characteristic %s not in required or optional characteristics for service %s. Adding anyway.", name.UUID, this.UUID);
+      return this.addCharacteristic(name);
     }
-    return this.addCharacteristic(name);
   }
 };
 
@@ -203,8 +203,8 @@ Service.prototype.getCharacteristicByIID = function(iid) {
 }
 
 Service.prototype._assignIDs = function(identifierCache, accessoryName, baseIID) {
-  if (baseIID===undefined) {
-    baseIID=0;
+  if (baseIID === undefined) {
+    baseIID = 0;
   }
   // the Accessory Information service must have a (reserved by IdentifierCache) ID of 1
   if (this.UUID === '0000003E-0000-1000-8000-0026BB765291') {

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var debug = require('debug')('Accessory'); //This is used to throw events about things done to accessories.
 var inherits = require('util').inherits;
 var clone = require('./util/clone').clone;
 var EventEmitter = require('events').EventEmitter;
@@ -145,19 +144,19 @@ Service.prototype.getCharacteristic = function(name) {
 			return characteristic;
 		}
 	}
-	if (typeof name === 'function')  {
-		for (index in this.optionalCharacteristics) {
-			characteristic = this.optionalCharacteristics[index];
-			if ((characteristic instanceof name) || (name.UUID === characteristic.UUID)) {
-				return this.addCharacteristic(name);
-			}
+  if (typeof name === 'function') {
+    for (index in this.optionalCharacteristics) {
+      characteristic = this.optionalCharacteristics[index];
+      if ((characteristic instanceof name) || (name.UUID === characteristic.UUID)) {
+        return this.addCharacteristic(name);
+      }
     }
     //Not found in optional Characteristics. Adding anyway, but warning about it if it isn't the Name.
     if (name !== Characteristic.Name) {
       console.warn("HAP Warning: Characteristic %s not in required or optional characteristics for service %s. Adding anyway.", name.UUID, this.UUID);
     }
     return this.addCharacteristic(name);
-	}
+  }
 };
 
 Service.prototype.testCharacteristic = function(name) {
@@ -204,10 +203,12 @@ Service.prototype.getCharacteristicByIID = function(iid) {
 }
 
 Service.prototype._assignIDs = function(identifierCache, accessoryName, baseIID) {
-  if (baseIID===undefined) baseIID=0;
+  if (baseIID===undefined) {
+    baseIID=0;
+  }
   // the Accessory Information service must have a (reserved by IdentifierCache) ID of 1
   if (this.UUID === '0000003E-0000-1000-8000-0026BB765291') {
-      this.iid = baseIID + 1;
+      this.iid = 1;
   }
   else {
     // assign our own ID based on our UUID

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var debug = require('debug')('Accessory'); //This is used to throw events about things done to accessories.
 var inherits = require('util').inherits;
 var clone = require('./util/clone').clone;
 var EventEmitter = require('events').EventEmitter;
@@ -150,12 +151,13 @@ Service.prototype.getCharacteristic = function(name) {
 			if ((characteristic instanceof name) || (name.UUID === characteristic.UUID)) {
 				return this.addCharacteristic(name);
 			}
-		}
-	}
+    }
     //Not found in optional Characteristics. Adding anyway, but warning about it if it isn't the Name.
-    if (name!==Characteristic.Name)
+    if (name !== Characteristic.Name) {
       console.warn("HAP Warning: Characteristic %s not in required or optional characteristics for service %s. Adding anyway.", name.UUID, this.UUID);
-  return this.addCharacteristic(name);
+    }
+    return this.addCharacteristic(name);
+	}
 };
 
 Service.prototype.testCharacteristic = function(name) {
@@ -201,15 +203,15 @@ Service.prototype.getCharacteristicByIID = function(iid) {
   }
 }
 
-Service.prototype._assignIDs = function(identifierCache, accessoryName) {
-
+Service.prototype._assignIDs = function(identifierCache, accessoryName, baseIID) {
+  if (baseIID===undefined) baseIID=0;
   // the Accessory Information service must have a (reserved by IdentifierCache) ID of 1
   if (this.UUID === '0000003E-0000-1000-8000-0026BB765291') {
-    this.iid = 1;
+      this.iid = baseIID + 1;
   }
   else {
     // assign our own ID based on our UUID
-    this.iid = identifierCache.getIID(accessoryName, this.UUID, this.subtype);
+    this.iid = baseIID + identifierCache.getIID(accessoryName, this.UUID, this.subtype);
   }
 
   // assign IIDs to our Characteristics

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hap-nodejs",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "HAP-NodeJS is a Node.js implementation of HomeKit Accessory Server.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This is intended to fix nfarina/homebridge#1433
The issue is that Apple removed an optional characteristic and so now, while the characteristic still exists, it's no longer in the optional list. This change would allow "getCharacteristic" to still auto-add it while displaying a warning so that the developer understands that the characteristic isn't in the optional list. If the developer uses "addCharacteristic" then the warning will not appear.
Is this a good way to handle this or should we just make the developer of that plugin fix the plugin to add?
I don't want to add the defunct characteristic as optional on the service because I want to make sure future projects don't see it as an option.