### PR TITLE
Additional string validation added (fallback)

### DIFF
--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -220,6 +220,7 @@ Characteristic.prototype.validateValue = function(newValue) {
       break;
     case 'string':
       var myString = newValue;
+      if (myString===undefined) myString="NA";
       var maxLength = this.props.maxLen;
       if (maxLength===undefined) maxLength=64; //Default Max Length is 64.
       if (myString.length>maxLength) myString = myString.substring(0,maxLength); //Truncate strings that are too long


### PR DESCRIPTION
Addresses an issue that causes a program crash if an empty string is submitted, e.g. manufacturer field in homebridge is empty. In that case string is defined as "NA"