### PR TITLE
expire unused ids optional

### DIFF
--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -57,6 +57,7 @@ function Accessory(displayName, UUID) {
   this.category = Accessory.Categories.OTHER;
   this.services = []; // of Service
   this.cameraSource = null;
+  this.shouldPurgeUnusedIDs = true; // Purge unused ids by default
 
   // create our initial "Accessory Information" Service that all Accessories are expected to have
   this
@@ -365,7 +366,8 @@ Accessory.prototype.configureCameraSource = function(cameraSource) {
 Accessory.prototype._assignIDs = function(identifierCache) {
 
   // if we are responsible for our own identifierCache, start the expiration process
-  if (this._identifierCache) {
+  // also check weather we want to have an expiration process
+  if (this._identifierCache && this.shouldPurgeUnusedIDs) {
     this._identifierCache.startTrackingUsage();
   }
 
@@ -399,9 +401,36 @@ Accessory.prototype._assignIDs = function(identifierCache) {
   // expire any now-unused cache keys (for Accessories, Services, or Characteristics
   // that have been removed since the last call to assignIDs())
   if (this._identifierCache) {
-    this._identifierCache.stopTrackingUsageAndExpireUnused();
+    //Check weather we want to purge the unused ids
+    if (this.shouldPurgeUnusedIDs)
+      this._identifierCache.stopTrackingUsageAndExpireUnused();
+    //Save in case we have new ones
     this._identifierCache.save();
   }
+}
+
+Accessory.prototype.disableUnusedIDPurge = function() {
+  this.shouldPurgeUnusedIDs = false;
+}
+
+Accessory.prototype.enableUnusedIDPurge = function() {
+  this.shouldPurgeUnusedIDs = true;
+}
+
+/**
+ * Manually purge the unused ids if you like, comes handy
+ * when you have disabled auto purge so you can do it manually
+ */
+Accessory.prototype.purgeUnusedIDs = function() {
+  //Cache the state of the purge mechanisam and set it to true
+  var oldValue = this.shouldPurgeUnusedIDs;
+  this.shouldPurgeUnusedIDs = true;
+
+  //Reassign all ids
+  this._assignIDs(this._identifierCache);
+
+  //Revert back the purge mechanisam state
+  this.shouldPurgeUnusedIDs = oldValue;
 }
 
 /**
@@ -476,6 +505,13 @@ Accessory.prototype.publish = function(info, allowInsecureRequest) {
     debug("[%s] Creating new IdentifierCache", this.displayName);
     this._identifierCache = new IdentifierCache(info.username);
   }
+
+  //If it's bridge and there are not accessories already assigned to the bridge 
+  //probably purge is not needed since it's going to delete all the ids 
+  //of accessories that might be added later. Usefull when dynamically adding 
+  //accessories. 
+  if (this._isBridge && this.bridgedAccessories.length == 0)
+    this.disableUnusedIDPurge();
 
   // assign aid/iid
   this._assignIDs(this._identifierCache);


### PR DESCRIPTION
If a bridge is published without any accessories and the accessories are added later the functionality to expire unused ids in the IdentifierCache is removing all the ID's and that's creating mess on the iOS later when the accessories are dynamically added. So i added functionality to disable the 'expire unusdes ids' also a check in the publish weather the accessory is bridge and the length of bridgedAccessories in the bridge is 0 then disable the 'expire unusdes ids'.