### PR TITLE
update IdentifierCache.js so that cache is persisted to disk only if …

### DIFF
--- a/lib/model/IdentifierCache.js
+++ b/lib/model/IdentifierCache.js
@@ -2,6 +2,7 @@
 
 var util = require('util');
 var storage = require('node-persist');
+var crypto = require('crypto');
 
 module.exports = {
   IdentifierCache: IdentifierCache
@@ -21,6 +22,7 @@ function IdentifierCache(username) {
   this.username = username;
   this._cache = {}; // cache[key:string] = id:number
   this._usedCache = null; // for usage tracking and expiring old keys
+  this._savedCacheHash = ""; // for checking if new cache neeed to be saved
 }
 
 IdentifierCache.prototype.startTrackingUsage = function() {
@@ -105,6 +107,7 @@ IdentifierCache.load = function(username) {
   if (saved) {
     var info = new IdentifierCache(username);
     info._cache = saved.cache;
+    info._savedCacheHash = crypto.createHash('sha1').update(JSON.stringify(info._cache)).digest('hex'); //calculate hash of the saved hash to decide in future if saving of new cache is neeeded
     return info;
   }
   else {
@@ -113,14 +116,18 @@ IdentifierCache.load = function(username) {
 };
 
 IdentifierCache.prototype.save = function() {
-  var saved = {
-    cache: this._cache
-  };
+  var newCacheHash = crypto.createHash('sha1').update(JSON.stringify(this._cache)).digest('hex'); //calculate hash of new cache
+  if (newCacheHash != this._savedCacheHash) {  //check if cache need to be saved and proceed accordingly
+    var saved = {
+      cache: this._cache
+    };
 
-  var key = IdentifierCache.persistKey(this.username);
+    var key = IdentifierCache.persistKey(this.username);
 
-  storage.setItemSync(key, saved);
-  storage.persistSync();
+    storage.setItemSync(key, saved);
+    storage.persistSync();
+    this._savedCacheHash = newCacheHash;  //update hash of saved cache for future use
+  }
 };
 
 IdentifierCache.prototype.remove = function () {


### PR DESCRIPTION
This PR is intended to avoid unneeded saving of IdentifierCache to disk.

On my RaspPI I noticed an unusual IO activity due to homebridge. At the end I discovered this is related to a periodic call of the "accessories" event by the clients, which then calls the AssignIDs function, eventually ending in any case with a call to IdentifierCache.Save.

This PR ensures that actual saving is performed only if really needed, by calculating the hash of the cache currently on disk and comparing it with that of the updated cache built by AssignIDs function. This compare method is the same already employed to determine if AccessoryInfo need to be saved. Note however two differences:
1 - Hash is not saved into the cache file (as opposed to what is done with AccessoryInfo), but calculated on load, stored in memory and updated on saving, in order not to break existing installations with a different cache file format
2 - Hashing and checking are done directly in the IdentifierCache class (in Load and Save method), and not by the caller (as done for AccessoryInfo), in order to be more transparent to future development.