### PR TITLE
Update minvalue of CurrentTemperature

### DIFF
--- a/lib/gen/HomeKitTypes.js
+++ b/lib/gen/HomeKitTypes.js
@@ -680,7 +680,7 @@ Characteristic.CurrentTemperature = function() {
     format: Characteristic.Formats.FLOAT,
     unit: Characteristic.Units.CELSIUS,
     maxValue: 100,
-    minValue: 0,
+    minValue: -99, //manual update to support negative temperature on external sensors
     minStep: 0.1,
     perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
   });


### PR DESCRIPTION
With this PR, negative values on CurrentTemperature characteristic are now allowed. This is useful for external temperature sensors, that with the current settings saturates to zero, making necessary an override in the plugin. I also tested the new negative boundary modifying the corresponding file in Homekit Accessory Simulator, and the resulting simulated accessory is correctly seen by Home.app and Eve.app, so there not seems to be any hard limit in HAP protocol.
I was reluctant to make this PR, since this file was originally autogenerated, but then I saw several manual commits, so I decided to try. I leave the decision to merge it or not to the admins.
Thanks