### PR TITLE
Add more logging to understand the event issues in 0.4.35

### DIFF
--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -930,6 +930,7 @@ Accessory.prototype._handleSessionClose = function(sessionID, events) {
 }
 
 Accessory.prototype._unsubscribeEvents = function (events) {
+  debug('[%s] Unsubscribe all events of a controller connection', this.displayName);
   for (var key in events) {
     if (key.indexOf('.') !== -1) {
       try {
@@ -969,6 +970,7 @@ Accessory.prototype._handleCharacteristicChange = function(change) {
   var excludeEvents = change.context;
 
   // pass it along to notifyClients() so that it can omit the connection where events === excludeEvents.
+  debug('[%s] Notify clients of %o', this.displayName, data);
   this._server.notifyClients(eventName, data, excludeEvents);
 }
 

--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -4,6 +4,7 @@ var inherits = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
 var once = require('./util/once').once;
 var Decimal = require('decimal.js');
+var debug = require('debug')('Characteristic');
 
 module.exports = {
   Characteristic: Characteristic
@@ -131,16 +132,21 @@ Characteristic.prototype.setProps = function(props) {
 
 Characteristic.prototype.subscribe = function () {
   if (this.subscriptions === 0) {
+    debug('[%s] Emit subscribe', this.displayName); 
     this.emit('subscribe');
   }
+
   this.subscriptions++;
+  debug('[%s] Subscribe: %o total subscriptions', this.displayName, this.subscriptions);
 }
 
 Characteristic.prototype.unsubscribe = function() {
   var wasOne = this.subscriptions === 1;
   this.subscriptions--;
   this.subscriptions = Math.max(this.subscriptions, 0);
+  debug('[%s] Unsubscribe: %o total subscriptions', this.displayName, this.subscriptions);
   if (wasOne) {
+    debug('[%s] Emit unsubscribe', this.displayName);
     this.emit('unsubscribe');
   }
 }
@@ -344,8 +350,9 @@ Characteristic.prototype.setValue = function(newValue, callback, context, connec
   return this; // for chaining
 }
 
-Characteristic.prototype.updateValue = function(newValue, callback, context) {
+Characteristic.prototype.updateValue = function (newValue, callback, context) {
   newValue = this.validateValue(newValue); //validateValue returns a value that has be cooerced into a valid value.
+  debug('[%s] Characteristic change %o', this.displayName, newValue);
   
   if (newValue === undefined || newValue === null)
     newValue = this.getDefaultValue();

--- a/lib/util/eventedhttp.js
+++ b/lib/util/eventedhttp.js
@@ -155,6 +155,7 @@ EventedHTTPServerConnection.prototype.sendEvent = function(event, data, contentT
 
   // has this connection subscribed to the given event? if not, nothing to do!
   if (!this._events[event]) {
+    debug('[%s] Not sending event to client %o', this._remoteAddress, event);
     return;
   }
 


### PR DESCRIPTION
Some users are reporting issues that events get stuck with 0.4.35 and that reverting to 0.4.34 resolves that. I currently do not understand the reasons and am investigating this and hope that the additional logs might lead to a better understanding of the issue.

The issue only appears after several hours and seems to resolve itself by either restarting homebridge  or restarting the HomeKit Hubs.