### PR TITLE
Change updateValue to return not responding status

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var uuid = require('./lib/util/uuid');
 var AccessoryLoader = require('./lib/AccessoryLoader.js');
 var StreamController = require('./lib/StreamController.js').StreamController;
 var storage = require('node-persist');
+var HAPServer = require('./lib/HAPServer').HAPServer;
 
 // ensure Characteristic subclasses are defined
 var HomeKitTypes = require('./lib/gen/HomeKitTypes');
@@ -20,7 +21,8 @@ module.exports = {
   Characteristic: Characteristic,
   uuid: uuid,
   AccessoryLoader: AccessoryLoader,
-  StreamController: StreamController
+  StreamController: StreamController,
+  HAPServer: HAPServer
 }
 
 function init(storagePath) {

--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -192,7 +192,7 @@ Accessory.prototype.setPrimaryService = function (service) {
             break;
         }
     }
-     
+
     if (targetServiceIndex) {
         //If the service is found, set isPrimaryService to false for everything.
         for (var index in this.services)
@@ -556,10 +556,10 @@ Accessory.prototype.publish = function(info, allowInsecureRequest) {
     this._identifierCache = new IdentifierCache(info.username);
   }
 
-  //If it's bridge and there are not accessories already assigned to the bridge 
-  //probably purge is not needed since it's going to delete all the ids 
-  //of accessories that might be added later. Usefull when dynamically adding 
-  //accessories. 
+  //If it's bridge and there are not accessories already assigned to the bridge
+  //probably purge is not needed since it's going to delete all the ids
+  //of accessories that might be added later. Usefull when dynamically adding
+  //accessories.
   if (this._isBridge && this.bridgedAccessories.length == 0)
     this.disableUnusedIDPurge();
 
@@ -763,7 +763,7 @@ Accessory.prototype._handleGetCharacteristics = function(data, events, callback,
           aid: aid,
           iid: iid
         };
-        response[statusKey] = HAPServer.Status.SERVICE_COMMUNICATION_FAILURE; // generic error status
+        response[statusKey] = hapStatus(err);
         characteristics.push(response);
       }
       else {
@@ -873,7 +873,7 @@ Accessory.prototype._handleSetCharacteristics = function(data, events, callback,
             aid: aid,
             iid: iid
           };
-          response[statusKey] = HAPServer.Status.SERVICE_COMMUNICATION_FAILURE; // generic error status
+          response[statusKey] = hapStatus(err);
           characteristics.push(response);
         }
         else {
@@ -1029,4 +1029,23 @@ Accessory.prototype._generateSetupID = function() {
   }
 
   return setupID;
+}
+
+function hapStatus(err) {
+
+  // Validate that the message is a valid HAPServer.Status
+  var value = 0;  // default if not found or
+
+  for( const k in HAPServer.Status ) {
+    if (HAPServer.Status[k] == err.message)
+    {
+      value = err.message;
+      break;
+    }
+  }
+
+  if ( value == 0 )
+    value = HAPServer.Status.SERVICE_COMMUNICATION_FAILURE;  // default if not found or 0
+
+  return(parseInt(value));
 }

--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -47,6 +47,7 @@ function Characteristic(displayName, UUID, props) {
   this.UUID = UUID;
   this.iid = null; // assigned by our containing Service
   this.value = null;
+  this.status = null;
   this.eventOnlyCharacteristic = false;
   this.props = props || {
     format: null,
@@ -159,7 +160,7 @@ Characteristic.prototype.getValue = function(callback, context, connectionID) {
 
     // allow a listener to handle the fetching of this value, and wait for completion
     this.emit('get', once(function(err, newValue) {
-
+      this.status = err;
       if (err) {
         // pass the error along to our callback
         if (callback) callback(err);
@@ -185,7 +186,7 @@ Characteristic.prototype.getValue = function(callback, context, connectionID) {
 
     // no one is listening to the 'get' event, so just return the cached value
     if (callback)
-      callback(null, this.value);
+      callback(this.status, this.value);
   }
 }
 
@@ -234,7 +235,7 @@ Characteristic.prototype.validateValue = function(newValue) {
       maxValue_resolved=18446744073709551615;
       isNumericType=true;
       break;
-    //All of the following datatypes return from this switch.    
+    //All of the following datatypes return from this switch.
      case 'bool':
       return (newValue == true); //We don't need to make sure this returns true or false
       break;
@@ -244,7 +245,7 @@ Characteristic.prototype.validateValue = function(newValue) {
       var maxLength = this.props.maxLen;
       if (maxLength === undefined) maxLength=64; //Default Max Length is 64.
       if (myString.length>maxLength) myString = myString.substring(0,maxLength); //Truncate strings that are too long
-      return myString; //We don't need to do any validation after having truncated the string   
+      return myString; //We don't need to do any validation after having truncated the string
       break;
     case 'data':
       var maxLength = this.props.maxDataLen;
@@ -259,7 +260,7 @@ Characteristic.prototype.validateValue = function(newValue) {
     default: //Datatype out of HAP Spec encountered. We'll assume the developer knows what they're doing.
       return newValue;
     };
-    
+
   if (isNumericType) {
     if (isNaN(newValue)) return this.value; //This is not a number so we'll just pass out the last value.
     if (newValue === false) return 0;
@@ -267,12 +268,12 @@ Characteristic.prototype.validateValue = function(newValue) {
     if ((!isNaN(this.props.maxValue))&&(this.props.maxValue!==null)) maxValue_resolved=this.props.maxValue;
     if ((!isNaN(this.props.minValue))&&(this.props.minValue!==null)) minValue_resolved=this.props.minValue;
     if ((!isNaN(this.props.minStep))&&(this.props.minStep!==null)) minStep_resolved=this.props.minStep;
-  
+
     if (newValue<minValue_resolved) newValue = minValue_resolved; //Fails Minimum Value Test
     if (newValue>maxValue_resolved) newValue = maxValue_resolved; //Fails Maximum Value Test
     if (minStep_resolved!==undefined) {
       //Determine how many decimals we need to display
-      if (Math.floor(minStep_resolved) === minStep_resolved) 
+      if (Math.floor(minStep_resolved) === minStep_resolved)
         stepDecimals = 0;
       else
         stepDecimals = minStep_resolved.toString().split(".")[1].length || 0;
@@ -289,10 +290,10 @@ Characteristic.prototype.validateValue = function(newValue) {
         }
       } catch (e) {
         return this.value; //If we had an error, return the current value.
-      }      
+      }
     }
 
-    if (this['valid-values']!==undefined) 
+    if (this['valid-values']!==undefined)
       if (!this['valid-values'].includes(newValue)) return this.value; //Fails Valid Values Test
     if (this['valid-values-range']!==undefined) { //This is another way Apple has to handle min/max
       if (newValue<this['valid-values-range'][0]) newValue=this['valid-values-range'][0];
@@ -303,13 +304,20 @@ Characteristic.prototype.validateValue = function(newValue) {
 }
 
 Characteristic.prototype.setValue = function(newValue, callback, context, connectionID) {
+
+  if ( newValue instanceof Error ) {
+    this.status = newValue
+  } else {
+    this.status = null;
+  }
+
   newValue = this.validateValue(newValue); //validateValue returns a value that has be cooerced into a valid value.
 
   if (this.listeners('set').length > 0) {
 
     // allow a listener to handle the setting of this value, and wait for completion
     this.emit('set', newValue, once(function(err) {
-
+      this.status = err;
       if (err) {
         // pass the error along to our callback
         if (callback) callback(err);
@@ -345,8 +353,15 @@ Characteristic.prototype.setValue = function(newValue, callback, context, connec
 }
 
 Characteristic.prototype.updateValue = function(newValue, callback, context) {
+
+  if ( newValue instanceof Error ) {
+    this.status = newValue
+  } else {
+    this.status = null;
+  }
+
   newValue = this.validateValue(newValue); //validateValue returns a value that has be cooerced into a valid value.
-  
+
   if (newValue === undefined || newValue === null)
     newValue = this.getDefaultValue();
     // no one is listening to the 'set' event, so just assign the value blindly


### PR DESCRIPTION
I have been moving my plugins away from using getValue to return the current accessory state, and switching to a event based model, and having the plugin push state via updateValue or setValue. ( I'm switching to this event based model, to improve the responsiveness of the Home app and reduce the lagging caused by the callouts to remote devices to return state. ) While this works really well, what is lacking is the ability to deal with accessories that are not responding for various reasons, as the updateValue and setValue don't accept a value of 'Error'. And I'm not aware of any way to set a 'Not Responding' for an accessory either thru a characteristic or the HAP event interface, except as a response to "GET /characteristics".

Creates a characteristic level status 'this.status' - Value is null or the Error returned by the callback.

Changes updateValue and setValue to accept "Error" as a newValue, and update the status.

Changes getValue to include status as part of the response when there are no listeners to the get event

To use the feature, have the value updated by updateValue or setValue be an instance of Error. During the next get characteristics request, the accessory will display 'Not responding'. When the device starts responding again, sending a valid value, that is not an instance of 'Error' will clear the 'Not responding' message after the next get characteristics.

ie use this for updateValue

`Accessory.getService(Service.Outlet).getCharacteristic(Characteristic.On).updateValue(new Error("Polling failed"));`

**Optional additional functionality**

If you want to set a particular HAP return code, have the error be the HAP return code.

ie use this instead for updateValue

`Accessory.getService(Service.Outlet).getCharacteristic(Characteristic.On).updateValue(new Error(HAPServer.Status.SERVICE_COMMUNICATION_FAILURE));`

To gain access to the HAPServer Status codes, add these 2 HAPServer lines to the start of your plugin. 

var Accessory, Service, Characteristic, UUIDGen, **HAPServer**;

module.exports = function(homebridge) {

  Accessory = homebridge.platformAccessory;
  Service = homebridge.hap.Service;
  Characteristic = homebridge.hap.Characteristic;
  UUIDGen = homebridge.hap.uuid;
  **HAPServer = homebridge.hap.HAPServer**;

  homebridge.registerPlatform("homebridge-ecoplugs", "EcoPlug", EcoPlugPlatform);
}

