### PR TITLE
Changes SSRC to be random per prepareStream, not always 1

### DIFF
--- a/lib/Camera.js
+++ b/lib/Camera.js
@@ -99,9 +99,12 @@ Camera.prototype.prepareStream = function(request, callback) {
     let srtp_key = videoInfo["srtp_key"];
     let srtp_salt = videoInfo["srtp_salt"];
 
+    // SSRC is a 32 bit integer that is unique per stream
+    let ssrc = crypto.randomBytes(4).readUInt32BE(0, true)
+
     let videoResp = {
       port: targetPort,
-      ssrc: 1,
+      ssrc: ssrc,
       srtp_key: srtp_key,
       srtp_salt: srtp_salt
     };
@@ -110,7 +113,7 @@ Camera.prototype.prepareStream = function(request, callback) {
 
     sessionInfo["video_port"] = targetPort;
     sessionInfo["video_srtp"] = Buffer.concat([srtp_key, srtp_salt]);
-    sessionInfo["video_ssrc"] = 1; 
+    sessionInfo["video_ssrc"] = ssrc; 
   }
 
   let audioInfo = request["audio"];
@@ -119,9 +122,12 @@ Camera.prototype.prepareStream = function(request, callback) {
     let srtp_key = audioInfo["srtp_key"];
     let srtp_salt = audioInfo["srtp_salt"];
 
+    // SSRC is a 32 bit integer that is unique per stream
+    let ssrc = crypto.randomBytes(4).readUInt32BE(0, true)
+
     let audioResp = {
       port: targetPort,
-      ssrc: 1,
+      ssrc: ssrc,
       srtp_key: srtp_key,
       srtp_salt: srtp_salt
     };
@@ -130,7 +136,7 @@ Camera.prototype.prepareStream = function(request, callback) {
 
     sessionInfo["audio_port"] = targetPort;
     sessionInfo["audio_srtp"] = Buffer.concat([srtp_key, srtp_salt]);
-    sessionInfo["audio_ssrc"] = 1; 
+    sessionInfo["audio_ssrc"] = ssrc; 
   }
 
   let currentAddress = ip.address();
@@ -181,8 +187,9 @@ Camera.prototype.handleStreamRequest = function(request) {
         let targetAddress = sessionInfo["address"];
         let targetVideoPort = sessionInfo["video_port"];
         let videoKey = sessionInfo["video_srtp"];
+        let videoSsrc = sessionInfo["video_ssrc"]
 
-        let ffmpegCommand = '-re -f avfoundation -r 29.970000 -i 0:0 -threads 0 -vcodec libx264 -an -pix_fmt yuv420p -r '+ fps +' -f rawvideo -tune zerolatency -vf scale='+ width +':'+ height +' -b:v '+ bitrate +'k -bufsize '+ bitrate +'k -payload_type 99 -ssrc 1 -f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params '+videoKey.toString('base64')+' srtp://'+targetAddress+':'+targetVideoPort+'?rtcpport='+targetVideoPort+'&localrtcpport='+targetVideoPort+'&pkt_size=1378';
+        let ffmpegCommand = '-re -f avfoundation -r 29.970000 -i 0:0 -threads 0 -vcodec libx264 -an -pix_fmt yuv420p -r '+ fps +' -f rawvideo -tune zerolatency -vf scale='+ width +':'+ height +' -b:v '+ bitrate +'k -bufsize '+ bitrate +'k -payload_type 99 -ssrc '+ videoSsrc +' -f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params '+videoKey.toString('base64')+' srtp://'+targetAddress+':'+targetVideoPort+'?rtcpport='+targetVideoPort+'&localrtcpport='+targetVideoPort+'&pkt_size=1378';
         let ffmpeg = spawn('ffmpeg', ffmpegCommand.split(' '), {env: process.env});
         this.ongoingSessions[sessionIdentifier] = ffmpeg;
       }

--- a/lib/Camera.js
+++ b/lib/Camera.js
@@ -10,6 +10,7 @@ var Characteristic = require('./Characteristic').Characteristic;
 var StreamController = require('./StreamController').StreamController;
 var HomeKitTypes = require('./gen/HomeKitTypes');
 
+var crypto = require('crypto');
 var fs = require('fs');
 var ip = require('ip');
 var spawn = require('child_process').spawn;

--- a/lib/Camera.js
+++ b/lib/Camera.js
@@ -101,7 +101,7 @@ Camera.prototype.prepareStream = function(request, callback) {
     let srtp_salt = videoInfo["srtp_salt"];
 
     // SSRC is a 32 bit integer that is unique per stream
-    let ssrc = crypto.randomBytes(4).readUInt32BE(0, true)
+    let ssrc = crypto.randomBytes(4).readUInt32BE(0, true);
 
     let videoResp = {
       port: targetPort,
@@ -124,7 +124,7 @@ Camera.prototype.prepareStream = function(request, callback) {
     let srtp_salt = audioInfo["srtp_salt"];
 
     // SSRC is a 32 bit integer that is unique per stream
-    let ssrc = crypto.randomBytes(4).readUInt32BE(0, true)
+    let ssrc = crypto.randomBytes(4).readUInt32BE(0, true);
 
     let audioResp = {
       port: targetPort,
@@ -188,7 +188,7 @@ Camera.prototype.handleStreamRequest = function(request) {
         let targetAddress = sessionInfo["address"];
         let targetVideoPort = sessionInfo["video_port"];
         let videoKey = sessionInfo["video_srtp"];
-        let videoSsrc = sessionInfo["video_ssrc"]
+        let videoSsrc = sessionInfo["video_ssrc"];
 
         let ffmpegCommand = '-re -f avfoundation -r 29.970000 -i 0:0 -threads 0 -vcodec libx264 -an -pix_fmt yuv420p -r '+ fps +' -f rawvideo -tune zerolatency -vf scale='+ width +':'+ height +' -b:v '+ bitrate +'k -bufsize '+ bitrate +'k -payload_type 99 -ssrc '+ videoSsrc +' -f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params '+videoKey.toString('base64')+' srtp://'+targetAddress+':'+targetVideoPort+'?rtcpport='+targetVideoPort+'&localrtcpport='+targetVideoPort+'&pkt_size=1378';
         let ffmpeg = spawn('ffmpeg', ffmpegCommand.split(' '), {env: process.env});


### PR DESCRIPTION
This fixes the issue where you could not connect to multiple cameras at once when live.

SSRC should be a random 32 bit integer not always set to 1 for HomeKit to correctly be able to differentiate which stream is for which camera.

I have made it random on both audio and video streams, and have modified the ffmpeg call to correctly use this ssrc.