### PR TITLE
Missing Characteristic

### DIFF
--- a/lib/gen/HomeKitTypes.js
+++ b/lib/gen/HomeKitTypes.js
@@ -2951,7 +2951,8 @@ Service.Faucet = function(displayName, subtype) {
 
   // Required Characteristics
   this.addCharacteristic(Characteristic.Active);
-
+  this.addCharacteristic(Characteristic.InUse);
+  
   // Optional Characteristics
   this.addOptionalCharacteristic(Characteristic.Name);
   this.addOptionalCharacteristic(Characteristic.StatusFault);


### PR DESCRIPTION
Line 2954 of the HomeKitTypes.js file has been edited to add the "InUse" characteristic to Service.Faucet. InUse needs to be set this to 0 or 1 to indicate that a faucet has completed the open or closed command (the "Active" characteristic initiates the opening or closing of a faucet, and then InUse is set when that action successfully completes). Without the InUse being set to 0 or 1, the  iOS Home app can't tell when the faucet has actually turned on or off.

I realize the HomeKitTypes.js file is auto-generated and should not be manually edited, but was unclear how best to flag this error or where to place the fix. I assume you'll be able to fix it in the proper place and re-generate this file.

I discovered this as part of work I've been doing on a HomeSeer plugin and have confirmed that, with the InUse characteristic added, the Faucet Service works properly, but without it, the Home app can't detect the valve state.