### PR TITLE
Legacy Dictionary Fixes

### DIFF
--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -76,7 +76,7 @@ Characteristic.Formats = {
   DATA: 'data',
   TLV8: 'tlv8',
   ARRAY: 'array', //Not in HAP Spec
-  DICTIONARY: 'dictionary' //Not in HAP Spec
+  DICTIONARY: 'dict' //Not in HAP Spec
 }
 
 // Known HomeKit unit types
@@ -380,6 +380,7 @@ Characteristic.prototype.getDefaultValue = function() {
     case Characteristic.Formats.STRING: return "";
     case Characteristic.Formats.DATA: return null; // who knows!
     case Characteristic.Formats.TLV8: return null; // who knows!
+    case Characteristic.Formats.DICTIONARY: return {};
     default: return this.props.minValue || 0;
   }
 }

--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -381,6 +381,7 @@ Characteristic.prototype.getDefaultValue = function() {
     case Characteristic.Formats.DATA: return null; // who knows!
     case Characteristic.Formats.TLV8: return null; // who knows!
     case Characteristic.Formats.DICTIONARY: return {};
+    case Characteristic.Formats.ARRAY: return [];
     default: return this.props.minValue || 0;
   }
 }


### PR DESCRIPTION
JSON Dictionary objects are legacy supported with reads, but no writes (in iOS 11 at least).
The format key is ‘dict’, you will not be able to pair with the accessory if you define a characteristic with format ‘dictionary’.
Also there needs to be a default value of {} or the pairing will fail as well.