### PR TITLE
Add setupURI to the TypeScript def for Accessory

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -330,6 +330,7 @@ declare namespace HAPNodeJS {
         toHAP(opt: any): JSON;
         publish(info: PublishInfo, allowInsecureRequest: boolean): void;
         destroy(): void;
+        setupURI(): string;
     }
 
     module Accessory {


### PR DESCRIPTION
The method was added in https://github.com/KhaosT/HAP-NodeJS/commit/c62294b3c5400157164a10a1e96a41259c3fc23b but was not added to the interface.