### PR TITLE
Fix types of services exposed by Service

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,44 +42,48 @@ declare namespace HAPNodeJS {
 
         toHAP(opt: any): JSON;
 
-        AccessoryInformation: Service;
-        AirPurifier: Service;
-        AirQualitySensor: Service;
-        BatteryService: Service;
-        CameraControl: Service;
-        CameraRTPStreamManagement: Service;
-        CarbonDioxideSensor: Service;
-        CarbonMonoxideSensor: Service;
-        ContactSensor: Service;
-        Door: Service;
-        Doorbell: Service;
-        Fan: Service;
-        Fanv2: Service;
-        FilterMaintenance: Service;
-        GarageDoorOpener: Service;
-        HeaterCooler: Service;
-        HumidifierDehumidifier: Service;
-        HumiditySensor: Service;
-        LeakSensor: Service;
-        LightSensor: Service;
-        Lightbulb: Service;
-        LockManagement: Service;
-        LockMechanism: Service;
-        Microphone: Service;
-        MotionSensor: Service;
-        OccupancySensor: Service;
-        Outlet: Service;
-        SecuritySystem: Service;
-        Slat: Service;
-        SmokeSensor: Service;
-        Speaker: Service;
-        StatefulProgrammableSwitch: Service;
-        StatelessProgrammableSwitch: Service;
-        Switch: Service;
-        TemperatureSensor: Service;
-        Thermostat: Service;
-        Window: Service;
-        WindowCovering: Service;
+        AccessoryInformation: PredefinedService;
+        AirPurifier: PredefinedService;
+        AirQualitySensor: PredefinedService;
+        BatteryService: PredefinedService;
+        CameraControl: PredefinedService;
+        CameraRTPStreamManagement: PredefinedService;
+        CarbonDioxideSensor: PredefinedService;
+        CarbonMonoxideSensor: PredefinedService;
+        ContactSensor: PredefinedService;
+        Door: PredefinedService;
+        Doorbell: PredefinedService;
+        Fan: PredefinedService;
+        Fanv2: PredefinedService;
+        FilterMaintenance: PredefinedService;
+        GarageDoorOpener: PredefinedService;
+        HeaterCooler: PredefinedService;
+        HumidifierDehumidifier: PredefinedService;
+        HumiditySensor: PredefinedService;
+        LeakSensor: PredefinedService;
+        LightSensor: PredefinedService;
+        Lightbulb: PredefinedService;
+        LockManagement: PredefinedService;
+        LockMechanism: PredefinedService;
+        Microphone: PredefinedService;
+        MotionSensor: PredefinedService;
+        OccupancySensor: PredefinedService;
+        Outlet: PredefinedService;
+        SecuritySystem: PredefinedService;
+        Slat: PredefinedService;
+        SmokeSensor: PredefinedService;
+        Speaker: PredefinedService;
+        StatefulProgrammableSwitch: PredefinedService;
+        StatelessProgrammableSwitch: PredefinedService;
+        Switch: PredefinedService;
+        TemperatureSensor: PredefinedService;
+        Thermostat: PredefinedService;
+        Window: PredefinedService;
+        WindowCovering: PredefinedService;
+    }
+    
+    export interface PredefinedService {
+        new (displayName: string, subtype: string): Service;
     }
 
     export interface CameraSource {


### PR DESCRIPTION
I'm using this project is [one of my projects](https://github.com/JosephDuffy/homebridge-pc-volume) and found that the type that each of the services on `Service` have appears to be wrong.

Each predefined service property, e.g. [`Speaker`](https://github.com/KhaosT/HAP-NodeJS/blob/9eaea6df40811ccc71664a1ab0c13736e759dac7/lib/gen/HomeKitTypes.js#L3365), is exposed as a `Service`, which has a constructor with the signature `(displayName: string, UUID: string, subtype: string): Service`, but I believe they actually have the signature `(displayName: string, subtype: string): Service`, because the UUID is predefined.

I have added a new type – `PredefinedService` – which has a constructor with the signature `(displayName: string, subtype: string): Service`, and updated the `index.d.ts` file.