### PR TITLE
During unpair make sure _advertiser is not null

### DIFF
--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -698,7 +698,9 @@ Accessory.prototype._handleUnpair = function(username, callback) {
   this._accessoryInfo.save();
 
   // update our advertisement so it can pick up on the paired status of AccessoryInfo
-  this._advertiser.updateAdvertisement();
+  if (this._advertiser) {
+    this._advertiser.updateAdvertisement();
+  }
 
   callback();
 }


### PR DESCRIPTION
In unpair handler I added extra check for _advertiser before we call update on it.
It fixes NRCHKB/node-red-contrib-homekit-bridged#22

In node-red-contrib-homekit-bridged we sometimes have situation like this:

- create bridge with accessory
- publish bridge
- add bridge in Home.app
- remove accessory from bridge and reload bridge
- bridge is not published due to no accessories
- remove bridge from Home.app cause fatal error (publish was not called so we have unassigned _advertiser)