### PR TITLE
Check number of bridged accessories

### DIFF
--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -16,6 +16,8 @@ var IdentifierCache = require('./model/IdentifierCache').IdentifierCache;
 var bufferShim = require('buffer-shims');
 // var RelayServer = require("./util/relayserver").RelayServer;
 
+const MAX_ACCESSORIES = 99; // Maximum number of bridged accessories per bridge.
+
 module.exports = {
   Accessory: Accessory
 };
@@ -264,6 +266,11 @@ Accessory.prototype.addBridgedAccessory = function(accessory, deferUpdate) {
     var existing = this.bridgedAccessories[index];
     if (existing.UUID === accessory.UUID)
       throw new Error("Cannot add a bridged Accessory with the same UUID as another bridged Accessory: " + existing.UUID);
+  }
+
+  // A bridge too far...
+  if (this.bridgedAccessories.length >= MAX_ACCESSORIES) {
+    throw new Error("Cannot Bridge more than 99 Accessories", MAX_ACCESSORIES);
   }
 
   // listen for changes in ANY characteristics of ANY services on this Accessory


### PR DESCRIPTION
Throw an error when trying to add more than 99 bridged accessories to a bridge.

It's mostly relevant for homebridge, where a plugin doesn't know how many accessories have already been exposed by other plugins.  This seems the cleanest place to implement the check, though.