### PR TITLE
Fix error message when adding >149 bridged accessories to a Bridge.

### DIFF
--- a/lib/Accessory.js
+++ b/lib/Accessory.js
@@ -270,7 +270,7 @@ Accessory.prototype.addBridgedAccessory = function(accessory, deferUpdate) {
 
   // A bridge too far...
   if (this.bridgedAccessories.length >= MAX_ACCESSORIES) {
-    throw new Error("Cannot Bridge more than 99 Accessories", MAX_ACCESSORIES);
+    throw new Error("Cannot Bridge more than " + MAX_ACCESSORIES + " Accessories");
   }
 
   // listen for changes in ANY characteristics of ANY services on this Accessory


### PR DESCRIPTION
See #658.