### PR TITLE
Add missing props of Service in Typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,10 @@ declare namespace HAPNodeJS {
         iid: string;
         characteristics: Characteristic[];
         optionalCharacteristics: Characteristic[];
+        
+        isHiddenService: boolean;
+        isPrimaryService: boolean;
+        linkedServices: Service[];
 
         addCharacteristic(characteristic: Characteristic | Function): Characteristic;
         setHiddenService(isHidden: boolean): void;


### PR DESCRIPTION
Adding the following props to Service in index.d.ts:
```
isHiddenService: boolean;
isPrimaryService: boolean;
linkedServices: Service[];
```

@mzyy94 thoughts on these changes?