### PR TITLE
Fix typo

### DIFF
--- a/accessories/AirConditioner_accessory.js
+++ b/accessories/AirConditioner_accessory.js
@@ -68,7 +68,7 @@ FanService.getCharacteristic(Characteristic.On)
   });
 
 
-// also add an "optional" Characteristic for spped
+// also add an "optional" Characteristic for speed
 FanService.addCharacteristic(Characteristic.RotationSpeed)
   .on('get', function(callback) {
     callback(null, ACTest_data.rSpeed);


### PR DESCRIPTION
apply #661 fix for AirConditioner_accessory.js

Maybe this example should be updated to use Service.HeaterCooler