### PR TITLE
 catch oldValue in setValue directly at the beginning

### DIFF
--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -315,6 +315,8 @@ Characteristic.prototype.setValue = function(newValue, callback, context, connec
 
   newValue = this.validateValue(newValue); //validateValue returns a value that has be cooerced into a valid value.
 
+  var oldValue = this.value;
+
   if (this.listeners('set').length > 0) {
 
     // allow a listener to handle the setting of this value, and wait for completion
@@ -328,7 +330,6 @@ Characteristic.prototype.setValue = function(newValue, callback, context, connec
         if (newValue === undefined || newValue === null)
           newValue = this.getDefaultValue();
         // setting the value was a success; so we can cache it now
-        var oldValue = this.value;
         this.value = newValue;
         if (callback) callback();
 
@@ -343,7 +344,6 @@ Characteristic.prototype.setValue = function(newValue, callback, context, connec
     if (newValue === undefined || newValue === null)
       newValue = this.getDefaultValue();
     // no one is listening to the 'set' event, so just assign the value blindly
-    var oldValue = this.value;
     this.value = newValue;
     if (callback) callback();
 


### PR DESCRIPTION
Catch oldValue in setValue directly at the beginning to make sure cha…nge events are triggered as soon as value change.

Reason: I found some Homebridge Plugins that break the whole "sending change events" process by setting the value itself in the set-handler. The result is that old and new value are the the same and no change event is triggered at all.

Example: https://github.com/YinHangCode/homebridge-mi-aqara/blob/master/parser/GatewayParser.js#L267

This change would fix this and really compare oldValue from timepoint of the setValue call with the new value
@KhaosT 