### PR TITLE
Reimplement /pairings route to match the HAP spec

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -11,14 +11,15 @@ import {
   CharacteristicSetCallback
 } from './Characteristic';
 import { Advertiser } from './Advertiser';
-import { HAPServer, HAPServerEventTypes, Status } from './HAPServer';
-import { AccessoryInfo } from './model/AccessoryInfo';
+import { Codes, HAPServer, HAPServerEventTypes, Status } from './HAPServer';
+import { AccessoryInfo, PairingInformation, PermissionTypes } from './model/AccessoryInfo';
 import { IdentifierCache } from './model/IdentifierCache';
 import {
   CharacteristicChange,
   CharacteristicData, CharacteristicValue,
   NodeCallback,
   Nullable,
+  PairingsCallback,
   ToHAPOptions,
   VoidCallback,
   WithUUID,
@@ -116,7 +117,9 @@ export type Resource = {
 
 type IdentifyCallback = VoidCallback;
 type PairCallback = VoidCallback;
-type UnpairCallback = VoidCallback;
+type AddPairingCallback = PairingsCallback<void>;
+type RemovePairingCallback = PairingsCallback<void>;
+type ListPairingsCallback = PairingsCallback<PairingInformation[]>;
 type HandleAccessoriesCallback = NodeCallback<{ accessories: any[] }>;
 type HandleGetCharacteristicsCallback = NodeCallback<Characteristic[]>;
 type HandleSetCharacteristicsCallback = NodeCallback<Characteristic[]>;
@@ -668,7 +671,9 @@ export class Accessory extends EventEmitter<Events> {
     this._server.on(HAPServerEventTypes.LISTENING, this._onListening);
     this._server.on(HAPServerEventTypes.IDENTIFY, this._handleIdentify);
     this._server.on(HAPServerEventTypes.PAIR, this._handlePair);
-    this._server.on(HAPServerEventTypes.UNPAIR, this._handleUnpair);
+    this._server.on(HAPServerEventTypes.ADD_PAIRING, this._handleAddPairing);
+    this._server.on(HAPServerEventTypes.REMOVE_PAIRING, this._handleRemovePairing);
+    this._server.on(HAPServerEventTypes.LIST_PAIRINGS, this._handleListPairings);
     this._server.on(HAPServerEventTypes.ACCESSORIES, this._handleAccessories);
     this._server.on(HAPServerEventTypes.GET_CHARACTERISTICS, this._handleGetCharacteristics);
     this._server.on(HAPServerEventTypes.SET_CHARACTERISTICS, this._handleSetCharacteristics);
@@ -752,7 +757,7 @@ export class Accessory extends EventEmitter<Events> {
 
     debug("[%s] Paired with client %s", this.displayName, username);
 
-    this._accessoryInfo && this._accessoryInfo.addPairedClient(username, publicKey);
+    this._accessoryInfo && this._accessoryInfo.addPairedClient(username, publicKey, PermissionTypes.ADMIN);
     this._accessoryInfo && this._accessoryInfo.save();
 
     // update our advertisement so it can pick up on the paired status of AccessoryInfo
@@ -761,22 +766,69 @@ export class Accessory extends EventEmitter<Events> {
     callback();
   }
 
-// Called when HAPServer wishes to remove/unpair the pairing information of a client
-  _handleUnpair = (username: string, callback: UnpairCallback) => {
-
-    debug("[%s] Unpairing with client %s", this.displayName, username);
-
-    // Unpair
-    this._accessoryInfo && this._accessoryInfo.removePairedClient(username);
-    this._accessoryInfo && this._accessoryInfo.save();
-
-    // update our advertisement so it can pick up on the paired status of AccessoryInfo
-    if (this._advertiser) {
-      this._advertiser.updateAdvertisement();
+// called when a controller adds an additional pairing
+  _handleAddPairing = (controller: string, username: string, publicKey: Buffer, permission: PermissionTypes, callback: AddPairingCallback) => {
+    if (!this._accessoryInfo) {
+      callback(Codes.UNAVAILABLE);
+      return;
     }
 
-    callback();
-  }
+    if (!this._accessoryInfo.hasAdminPermissions(controller)) {
+      callback(Codes.AUTHENTICATION);
+      return;
+    }
+
+    const existingKey = this._accessoryInfo.getClientPublicKey(username);
+    if (existingKey) {
+      if (existingKey.toString() !== publicKey.toString()) {
+        callback(Codes.UNKNOWN);
+        return;
+      }
+
+      this._accessoryInfo.updatePermission(username, permission);
+    } else {
+      this._accessoryInfo.addPairedClient(username, publicKey, permission);
+    }
+
+    this._accessoryInfo.save();
+    // there should be no need to update advertisement
+    callback(0);
+  };
+
+  _handleRemovePairing = (controller: string, username: string, callback: RemovePairingCallback) => {
+    if (!this._accessoryInfo) {
+      callback(Codes.UNAVAILABLE);
+      return;
+    }
+
+    if (!this._accessoryInfo.hasAdminPermissions(controller)) {
+      callback(Codes.AUTHENTICATION);
+      return;
+    }
+
+    this._accessoryInfo.removePairedClient(controller, username);
+    this._accessoryInfo.save();
+
+    if (!this._accessoryInfo.paired()) {
+      this._advertiser && this._advertiser.updateAdvertisement();
+    }
+
+    callback(0);
+  };
+
+  _handleListPairings = (controller: string, callback: ListPairingsCallback) => {
+    if (!this._accessoryInfo) {
+      callback(Codes.UNAVAILABLE);
+      return;
+    }
+
+    if (!this._accessoryInfo.hasAdminPermissions(controller)) {
+      callback(Codes.AUTHENTICATION);
+      return;
+    }
+
+    callback(0, this._accessoryInfo.listPairings());
+  };
 
 // Called when an iOS client wishes to know all about our accessory via JSON payload
   _handleAccessories = (callback: HandleAccessoriesCallback) => {

--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -3,11 +3,12 @@ import http, { IncomingMessage, OutgoingMessage, ServerResponse } from 'http';
 
 import createDebug from 'debug';
 import bufferShim from 'buffer-shims';
+import srp from 'fast-srp-hap';
 
 import * as uuid from './uuid';
-import { Nullable } from '../../types';
+import { Nullable, SessionIdentifier } from '../../types';
 import { EventEmitter } from '../EventEmitter';
-import { Session } from '../HAPServer';
+import { HAPEncryption } from '../HAPServer';
 
 const debug = createDebug('EventedHTTPServer');
 
@@ -133,6 +134,42 @@ export class EventedHTTPServer extends EventEmitter<Events> {
   }
 }
 
+export class Session {
+
+  static sessions: Record<string, Session> = {};
+
+  _connection: EventedHTTPServerConnection;
+
+  sessionID: SessionIdentifier;
+  encryption?: HAPEncryption;
+  srpServer?: srp.Server;
+  username?: string;
+
+  constructor(connection: EventedHTTPServerConnection) {
+    this._connection = connection;
+    this.sessionID = connection.sessionID;
+  }
+
+  establishSession = (username: string) => {
+    this.username = username;
+
+    Session.sessions[username] = this;
+  };
+
+  _connectionDestroyed = () => {
+    if (this.username)
+      delete Session.sessions[this.username];
+  };
+
+  destroyConnection = () => {
+    this._connection._clientSocket.destroy();
+  };
+
+  destroyConnectionAfterWrite = () => {
+    this._connection._killSocketAfterWrite = true;
+  };
+
+}
 
 /**
  * Manages a single iOS-initiated HTTP connection during its lifetime.
@@ -149,11 +186,12 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
   _pendingClientSocketData: Nullable<Buffer>;
   _fullySetup: boolean;
   _writingResponse: boolean;
+  _killSocketAfterWrite: boolean;
   _pendingEventData: Buffer;
   _clientSocket: Socket;
   _httpServer: http.Server;
   _serverSocket: Nullable<Socket>;
-  _session: { sessionID: string; };
+  _session: Session;
   _events: Record<string, boolean>;
   _httpPort?: number;
 
@@ -165,6 +203,7 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     this._pendingClientSocketData = bufferShim.alloc(0); // data received from client before HTTP proxy is fully setup
     this._fullySetup = false; // true when we are finished establishing connections
     this._writingResponse = false; // true while we are composing an HTTP response (so events can wait)
+    this._killSocketAfterWrite = false;
     this._pendingEventData = bufferShim.alloc(0); // event data waiting to be sent until after an in-progress HTTP response is being written
     // clientSocket is the socket connected to the actual iOS device
     this._clientSocket = clientSocket;
@@ -182,9 +221,7 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     this._httpServer.on('error', this._onHttpServerError);
     this._httpServer.listen(0);
     // an arbitrary dict that users of this class can store values in to associate with this particular connection
-    this._session = {
-      sessionID: this.sessionID
-    };
+    this._session = new Session(this);
     // a collection of event names subscribed to by this connection
     this._events = {}; // this._events[eventName] = true (value is arbitrary, but must be truthy)
     debug("[%s] New connection from client", this._remoteAddress);
@@ -292,6 +329,12 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
       data = encrypted.data!;
     // proxy it along to the client (iOS)
     this._clientSocket.write(data);
+
+    if (this._killSocketAfterWrite) {
+      setTimeout(() => {
+        this._clientSocket.destroy();
+      }, 10);
+    }
   }
 
   // Our internal HTTP Server has been closed (happens after we call this._httpServer.close() below)
@@ -341,6 +384,7 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     debug("[%s] Client connection closed", this._remoteAddress);
     // shutdown the other side
     this._serverSocket && this._serverSocket.destroy();
+    this._session._connectionDestroyed();
   }
 
   _onClientSocketError = (err: Error) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface ToHAPOptions {
 export type Callback = (...args: any[]) => void;
 export type NodeCallback<T> = (err: Nullable<Error> | undefined, data?: T) => void;
 export type VoidCallback = (err?: Nullable<Error>) => void;
+export type PairingsCallback<T> = (err: number, data?: T) => void;
 export type PrimitiveTypes = string | number | boolean;
 
 type HAPProps =


### PR DESCRIPTION
**Reimplemented /pairings route to correctly match the HAP spec:**
- added permission management for paired controllers
- validate add/remove pairing request:
  - check controller admin permission
  - do not allow overriding of public key (add)
- add support for list pairings requests
- unpair every regular user controller when last admin controller unpairs
- destroy session if controller unpairs itself or any currently connected controller gets unpaired

<br>
Also in this PR:

- completed list of tlv values and status codes
- matched error response of pair-verify process to the expected behavior according to the HAP spec


<br>
<br>
Everything in this PR is tested and fulfills the expectations of the HAP spec :)
Happy to answer any questions concerning this PR