### PR TITLE
Fixed: resource/snapshot requests for bridged cameras now work as intended

### DIFF
--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -853,11 +853,6 @@ export class HAPServer extends EventEmitter<Events> {
       response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
       return;
     }
-    if (this.listeners(HAPServerEventTypes.REQUEST_RESOURCE).length == 0) {
-      response.writeHead(405);
-      response.end();
-      return;
-    }
     if (request.method == "POST") {
       if (!session.encryption) {
         if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
@@ -877,7 +872,7 @@ export class HAPServer extends EventEmitter<Events> {
       this.emit(HAPServerEventTypes.REQUEST_RESOURCE, data, once((err: Error, resource: any) => {
         if (err) {
           debug("[%s] Error getting snapshot: %s", this.accessoryInfo.username, err.message);
-          response.writeHead(500);
+          response.writeHead(405);
           response.end();
         } else {
           response.writeHead(200, {"Content-Type": "image/jpeg"});


### PR DESCRIPTION
When HomeKit invokes a `/resource` request for a camera, which is not the primary accessory (for example for bridged cameras and maybe also multiple cameras in one bridge), HomeKit includes the `aid` property in the request to specify from which accessory the snapshot should be gathered. This property is currently ignored by HAP-NodeJS and as a result any sort of snapshot requests won't work for bridged cameras.
This PR fixes that issue.