### PR TITLE
Set default values when creating a CameraRTPStreamManagment service

### DIFF
--- a/src/lib/StreamController.ts
+++ b/src/lib/StreamController.ts
@@ -353,25 +353,25 @@ export class StreamController {
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         var data = tlv.encode( 0x01, this.streamStatus );
         callback(null, data.toString('base64'));
-      });
+      }).getValue();
 
     managementService
       .getCharacteristic(Characteristic.SupportedRTPConfiguration)!
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         callback(null, this.supportedRTPConfiguration);
-      });
+      }).getValue();
 
     managementService
       .getCharacteristic(Characteristic.SupportedVideoStreamConfiguration)!
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         callback(null, this.supportedVideoStreamConfiguration);
-      });
+      }).getValue();
 
     managementService
       .getCharacteristic(Characteristic.SupportedAudioStreamConfiguration)!
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         callback(null, this.supportedAudioStreamConfiguration);
-      });
+      }).getValue();
 
     managementService
       .getCharacteristic(Characteristic.SelectedRTPStreamConfiguration)!


### PR DESCRIPTION
When creating a new StreamController default values for the characteristics of the CameraRTPStreamManagment service are now correctly set.
After pairing with a newly created Camera/Video Doorbell accessory, for the first Discover call the value property for the characteristics of the CameraRTPStreamManagment service would be empty/non existent. HomeKit expects those values to be set.