### PR TITLE
 Implement /characteristics route according to the spec

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -8,7 +8,8 @@ import { Service, ServiceConfigurationChange, ServiceEventTypes } from './Servic
 import {
   Characteristic,
   CharacteristicEventTypes,
-  CharacteristicSetCallback
+  CharacteristicSetCallback,
+  Perms
 } from './Characteristic';
 import { Advertiser } from './Advertiser';
 import { HAPServer, HAPServerEventTypes, Status } from './HAPServer';
@@ -118,8 +119,8 @@ type IdentifyCallback = VoidCallback;
 type PairCallback = VoidCallback;
 type UnpairCallback = VoidCallback;
 type HandleAccessoriesCallback = NodeCallback<{ accessories: any[] }>;
-type HandleGetCharacteristicsCallback = NodeCallback<Characteristic[]>;
-type HandleSetCharacteristicsCallback = NodeCallback<Characteristic[]>;
+type HandleGetCharacteristicsCallback = NodeCallback<CharacteristicData[]>;
+type HandleSetCharacteristicsCallback = NodeCallback<CharacteristicData[]>;
 
 /**
  * Accessory is a virtual HomeKit device. It can publish an associated HAP server for iOS devices to communicate
@@ -794,7 +795,7 @@ export class Accessory extends EventEmitter<Events> {
   _handleGetCharacteristics = (data: CharacteristicData[], events: CharacteristicEvents, callback: HandleGetCharacteristicsCallback, remote: boolean, connectionID: string) => {
 
     // build up our array of responses to the characteristics requested asynchronously
-    var characteristics: Characteristic[] = [];
+    var characteristics: CharacteristicData[] = [];
     var statusKey = remote ? 's' : 'status';
     var valueKey = remote ? 'v' : 'value';
 
@@ -819,6 +820,21 @@ export class Accessory extends EventEmitter<Events> {
         if (characteristics.length === data.length)
           callback(null, characteristics);
 
+        return;
+      }
+
+      if (!characteristic.props.perms.includes(Perms.PAIRED_READ)) { // check if we are allowed to read from this characteristic
+        debug('[%s] Tried reading from Characteristic which does not allow reading (iid of %s and aid of %s)', this.displayName, characteristicData.aid, characteristicData.iid);
+        const response: any = {
+          aid: aid,
+          iid: iid
+        };
+        response[statusKey] = Status.WRITE_ONLY_CHARACTERISTIC;
+        characteristics.push(response);
+
+        if (characteristics.length === data.length) {
+          callback(null, characteristics);
+        }
         return;
       }
 
@@ -852,7 +868,6 @@ export class Accessory extends EventEmitter<Events> {
             iid: iid
           };
           response[valueKey] = value;
-          response[statusKey] = 0;
 
           if (includeEvent) {
             var eventName = aid + '.' + iid;
@@ -882,7 +897,7 @@ export class Accessory extends EventEmitter<Events> {
     debug("[%s] Processing characteristic set: %s", this.displayName, JSON.stringify(data));
 
     // build up our array of responses to the characteristics requested asynchronously
-    var characteristics: Characteristic[] = [];
+    var characteristics: CharacteristicData[] = [];
 
     data.forEach((characteristicData) => {
       var aid = characteristicData.aid;
@@ -921,6 +936,21 @@ export class Accessory extends EventEmitter<Events> {
       // if "ev" is present, that means we need to register or unregister this client for change events for
       // this characteristic.
       if (typeof ev !== 'undefined') {
+        if (!characteristic.props.perms.includes(Perms.NOTIFY)) { // check if notify is allowed for this characteristic
+          debug('[%s] Tried enabling notifications for Characteristic which does not allow notify (iid of %s and aid of %s)', this.displayName, characteristicData.aid, characteristicData.iid);
+          const response: any = {
+            aid: aid,
+            iid: iid
+          };
+          response[statusKey] = Status.NOTIFICATION_NOT_SUPPORTED;
+          characteristics.push(response);
+
+          if (characteristics.length === data.length) {
+            callback(null, characteristics);
+          }
+          return;
+        }
+
         debug('[%s] %s Characteristic "%s" for events', this.displayName, ev ? "Registering" : "Unregistering", characteristic.displayName);
 
         // store event registrations in the supplied "events" dict which is associated with the connection making
@@ -940,6 +970,20 @@ export class Accessory extends EventEmitter<Events> {
 
       // Found the characteristic - set the value if there is one
       if (typeof value !== 'undefined') {
+        if (!characteristic.props.perms.includes(Perms.PAIRED_WRITE)) { // check if write is allowed for this characteristic
+          debug('[%s] Tried writing to Characteristic which does not allow writing (iid of %s and aid of %s)', this.displayName, characteristicData.aid, characteristicData.iid);
+          const response: any = {
+            aid: aid,
+            iid: iid
+          };
+          response[statusKey] = Status.READ_ONLY_CHARACTERISTIC;
+          characteristics.push(response);
+
+          if (characteristics.length === data.length) {
+            callback(null, characteristics);
+          }
+          return;
+        }
 
         debug('[%s] Setting Characteristic "%s" to value %s', this.displayName, characteristic.displayName, value);
 

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -96,14 +96,14 @@ export type Events = {
   [HAPServerEventTypes.GET_CHARACTERISTICS]: (
     data: CharacteristicData[],
     events: CharacteristicEvents,
-    cb: NodeCallback<Characteristic[]>,
+    cb: NodeCallback<CharacteristicData[]>,
     remote: boolean,
     connectionID: string,
   ) => void;
   [HAPServerEventTypes.SET_CHARACTERISTICS]: (
     data: CharacteristicData[],
     events: CharacteristicEvents,
-    cb: NodeCallback<Characteristic[]>,
+    cb: NodeCallback<CharacteristicData[]>,
     remote: boolean,
     connectionID: string,
   ) => void;
@@ -674,7 +674,7 @@ export class HAPServer extends EventEmitter<Events> {
   _handlePairings = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: Buffer) => {
     // Only accept /pairing request if there is a secure session
     if (!this.allowInsecureRequest && !session.encryption) {
-      response.writeHead(401, {"Content-Type": "application/hap+json"});
+      response.writeHead(470, {"Content-Type": "application/hap+json"});
       response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
       return;
     }
@@ -719,7 +719,7 @@ export class HAPServer extends EventEmitter<Events> {
   // Called when the client wishes to fetch all data regarding our published Accessories.
   _handleAccessories = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: any) => {
     if (!this.allowInsecureRequest && !session.encryption) {
-      response.writeHead(401, {"Content-Type": "application/hap+json"});
+      response.writeHead(470, {"Content-Type": "application/hap+json"});
       response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
       return;
     }
@@ -763,7 +763,7 @@ export class HAPServer extends EventEmitter<Events> {
   // Called when the client wishes to get or set particular characteristics
   _handleCharacteristics = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: { length: number; toString: () => string; }) => {
     if (!this.allowInsecureRequest && !session.encryption) {
-      response.writeHead(401, {"Content-Type": "application/hap+json"});
+      response.writeHead(470, {"Content-Type": "application/hap+json"});
       response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
       return;
     }
@@ -789,7 +789,7 @@ export class HAPServer extends EventEmitter<Events> {
         var iid = parseInt(ids[1]); // instance ID (for characteristic)
         data.push({aid: aid, iid: iid});
       }
-      this.emit(HAPServerEventTypes.GET_CHARACTERISTICS, data, events, once((err: Error, characteristics: Characteristic[]) => {
+      this.emit(HAPServerEventTypes.GET_CHARACTERISTICS, data, events, once((err: Error, characteristics: CharacteristicData[]) => {
         if (!characteristics && !err)
           err = new Error("characteristics not supplied by the get-characteristics event callback");
         if (err) {
@@ -800,19 +800,29 @@ export class HAPServer extends EventEmitter<Events> {
             characteristics.push({
               aid: data[i].aid,
               iid: data[i].iid,
-              // @ts-ignore
               status: Status.SERVICE_COMMUNICATION_FAILURE
             });
           }
         }
-        // 207 is "multi-status" since HomeKit may be requesting multiple things and any one can fail independently
-        response.writeHead(207, {"Content-Type": "application/hap+json"});
+
+        let errorOccurred = false;
+        for (let i = 0; i < characteristics.length; i++) {
+          const value = characteristics[i];
+          if ((value.status !== undefined && value.status !== 0)
+              || (value.s !== undefined && value.s !== 0)) {
+            errorOccurred = true;
+            break;
+          }
+        }
+
+        // 207 "multi-status" is returned when an error occurs reading a characteristic. otherwise 200 is returned
+        response.writeHead(errorOccurred? 207: 200, {"Content-Type": "application/hap+json"});
         response.end(JSON.stringify({characteristics: characteristics}));
       }), false, session.sessionID);
     } else if (request.method == "PUT") {
       if (!session.encryption) {
         if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
-          response.writeHead(401, {"Content-Type": "application/hap+json"});
+          response.writeHead(470, {"Content-Type": "application/hap+json"});
           response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
           return;
         }
@@ -825,7 +835,7 @@ export class HAPServer extends EventEmitter<Events> {
       // requestData is a JSON payload like { characteristics: [ { aid: 1, iid: 8, value: true, ev: true } ] }
       var data = JSON.parse(requestData.toString()).characteristics as CharacteristicData[]; // pull out characteristics array
       // call out to listeners to retrieve the latest accessories JSON
-      this.emit(HAPServerEventTypes.SET_CHARACTERISTICS, data, events, once((err: Error, characteristics: Characteristic[]) => {
+      this.emit(HAPServerEventTypes.SET_CHARACTERISTICS, data, events, once((err: Error, characteristics: CharacteristicData[]) => {
         if (err) {
           debug("[%s] Error setting characteristics: %s", this.accessoryInfo.username, err.message);
           // rewrite characteristics array to include error status for each characteristic requested
@@ -839,9 +849,27 @@ export class HAPServer extends EventEmitter<Events> {
             });
           }
         }
-        // 207 is "multi-status" since HomeKit may be setting multiple things and any one can fail independently
-        response.writeHead(207, {"Content-Type": "application/hap+json"});
-        response.end(JSON.stringify({characteristics: characteristics}));
+
+        let multiStatus = false;
+        for (let i = 0; i < characteristics.length; i++) {
+          const characteristic = characteristics[i];
+          if ((characteristic.status !== undefined && characteristic.status !== 0)
+              || (characteristic.s !== undefined && characteristic.s !== 0)
+              || characteristic.value !== undefined) { // also send multiStatus on write response requests
+            multiStatus = true;
+            break;
+          }
+        }
+
+        if (multiStatus) {
+          // 207 is "multi-status" since HomeKit may be setting multiple things and any one can fail independently
+          response.writeHead(207, {"Content-Type": "application/hap+json"});
+          response.end(JSON.stringify({characteristics: characteristics}));
+        } else {
+          // if everything went fine send 204 no content response
+          response.writeHead(204); // 204 "No content"
+          response.end();
+        }
       }), false, session.sessionID);
     }
   }
@@ -849,7 +877,7 @@ export class HAPServer extends EventEmitter<Events> {
   // Called when controller request snapshot
   _handleResource = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: { length: number; toString: () => string; }) => {
     if (!this.allowInsecureRequest && !session.encryption) {
-      response.writeHead(401, {"Content-Type": "application/hap+json"});
+      response.writeHead(470, {"Content-Type": "application/hap+json"});
       response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
       return;
     }
@@ -861,7 +889,7 @@ export class HAPServer extends EventEmitter<Events> {
     if (request.method == "POST") {
       if (!session.encryption) {
         if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
-          response.writeHead(401, {"Content-Type": "application/hap+json"});
+          response.writeHead(470, {"Content-Type": "application/hap+json"});
           response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
           return;
         }
@@ -893,7 +921,7 @@ export class HAPServer extends EventEmitter<Events> {
   _handleRemoteCharacteristicsWrite = (request: HapRequest, remoteSession: RemoteSession, session: Session, events: any) => {
     var data = JSON.parse(request.requestBody.toString());
     // call out to listeners to retrieve the latest accessories JSON
-    this.emit(HAPServerEventTypes.SET_CHARACTERISTICS, data, events, once((err: Error, characteristics: Characteristic[]) => {
+    this.emit(HAPServerEventTypes.SET_CHARACTERISTICS, data, events, once((err: Error, characteristics: CharacteristicData[]) => {
       if (err) {
         debug("[%s] Error setting characteristics: %s", this.accessoryInfo.username, err.message);
         // rewrite characteristics array to include error status for each characteristic requested
@@ -912,7 +940,7 @@ export class HAPServer extends EventEmitter<Events> {
 
   _handleRemoteCharacteristicsRead = (request: HapRequest, remoteSession: RemoteSession, session: Session, events: any) => {
     var data = JSON.parse(request.requestBody.toString());
-    this.emit(HAPServerEventTypes.GET_CHARACTERISTICS, data, events, (err: Error, characteristics: Characteristic[]) => {
+    this.emit(HAPServerEventTypes.GET_CHARACTERISTICS, data, events, (err: Error, characteristics: CharacteristicData[]) => {
       if (!characteristics && !err)
         err = new Error("characteristics not supplied by the get-characteristics event callback");
       if (err) {


### PR DESCRIPTION
* Implement http response according to the spec:
  * for writes:
    * 204 "No Content" if no errors occurred
    * 207 "Multi-Status" if at least one characteristic reports an error or returns a write response
  * for reads:
    * 200 if no errors occurred (also do not include the `status` property if `value` was returned successfully)
    * 207 "Multi-Status" if at least one characteristic reports an error
* Added check to ensure operations performed on characteristics are actually permitted