### PR TITLE
Apple TV remote

### DIFF
--- a/src/accessories/AppleTVRemote_accessory.ts
+++ b/src/accessories/AppleTVRemote_accessory.ts
@@ -1,0 +1,168 @@
+import { Accessory, Categories, uuid } from '..';
+import { ButtonState, ButtonType, HomeKitRemoteController } from "../lib/HomeKitRemoteController";
+import * as http from "http";
+import url, { UrlWithParsedQuery } from "url";
+
+const remoteUUID = uuid.generate('hap-nodejs:accessories:remote');
+
+const remote = exports.accessory = new Accessory('Remote', remoteUUID);
+
+// @ts-ignore
+remote.username = "DB:AF:E0:5C:69:76";
+// @ts-ignore
+remote.pincode = "874-23-897";
+remote.category = Categories.TARGET_CONTROLLER;
+
+const controller = new HomeKitRemoteController();
+controller.addServicesToAccessory(remote);
+
+/*
+    This example plugin exposes an simple http api to interact with the remote and play around.
+    The supported routes are listed below. The http server runs on port 8080 as default.
+    This example should not be used except for testing as the http server is unsecured.
+
+    /press?button=<buttonId>&time=<timeInMS>  - presses a given button for a given time. Time is optional and defaults to 200
+    /button?button=<buttonId>&state=<stateId>  - send a single button event
+    /getTargetId?name=<name of apple TV>  -   get the target identifier for the given name of the apple tv
+    /setActiveTarget?identifier=<id>  - set currently controlled apple tv
+
+    /listTargets  -  list all currently configured apple tvs and their respective configuration
+    /getActiveTarget  -  return the current target id of the controlled device
+    /getActive  -  get the value of the active characteristic
+    /setActive  -  set the value of the active characteristic (HomeKit seems to set the accessory active itself after configuration)
+ */
+
+http.createServer((request, response) => {
+    if (request.method !== "GET") {
+        response.writeHead(405, {"Content-Type": "text/html"});
+        response.end("Method Not Allowed");
+        return;
+    }
+
+    const parsedPath: UrlWithParsedQuery = url.parse(request.url!, true);
+    const pathname = parsedPath.pathname!.substring(1, parsedPath.pathname!.length);
+    const query = parsedPath.query;
+
+    if (pathname === "setActiveTarget") {
+        if (query === undefined || query.identifier === undefined) {
+            response.writeHead(400, {"Content-Type": "text/html"});
+            response.end("Bad request. Must include 'identifier' in query string!");
+            return;
+        }
+
+        const targetIdentifier = parseInt(query.identifier as string, 10);
+        if (!controller.isConfigured(targetIdentifier)) {
+            response.writeHead(400, {"Content-Type": "text/html"});
+            response.end("Bad request. No target found for given identifier " + targetIdentifier);
+            return;
+        }
+
+        controller.setActiveIdentifier(targetIdentifier);
+        response.writeHead(200, {"Content-Type": "text/html"});
+        response.end("OK");
+        return;
+    } else if (pathname === "getActiveTarget") {
+        response.writeHead(200, {"Content-Type": "text/html"});
+        response.end(controller.activeIdentifier + "");
+        return;
+    } else if (pathname === "getTargetId") {
+        if (query === undefined || query.name === undefined) {
+            response.writeHead(400, {"Content-Type": "text/html"});
+            response.end("Bad request. Must include 'name' in query string!");
+            return;
+        }
+
+        const targetIdentifier = controller.getTargetIdentifierByName(query.name as string);
+        if (targetIdentifier === undefined) {
+            response.writeHead(400, {"Content-Type": "text/html"});
+            response.end("Bad request. No target found for given name " + query.name);
+            return;
+        }
+
+        response.writeHead(200, {"Content-Type": "text/html"});
+        response.end("" + targetIdentifier);
+        return;
+    } else if (pathname === "button") {
+        if (query === undefined || query.state === undefined || query.button === undefined) {
+            response.writeHead(400, {"Content-Type": "text/html"});
+            response.end("Bad request. Must include 'state' and 'button' in query string!");
+            return;
+        }
+
+        const buttonState = parseInt(query.state as string, 10);
+        const button = parseInt(query.button as string, 10);
+        if (ButtonState[buttonState] === undefined) {
+            response.writeHead(400, {"Content-Type": "text/html"});
+            response.end("Bad request. Unknown button state " + query.state);
+            return;
+        }
+        if (ButtonType[button] === undefined) {
+            response.writeHead(400, {"Content-Type": "text/html"});
+            response.end("Bad request. Unknown button " + query.button);
+            return;
+        }
+
+        if (buttonState === ButtonState.UP) {
+            controller.releaseButton(button);
+        } else if (buttonState === ButtonState.DOWN) {
+            controller.pushButton(button);
+        }
+
+        response.writeHead(200, {"Content-Type": "text/html"});
+        response.end("OK");
+        return;
+    } else if (pathname === "press") {
+        if (query === undefined || query.button === undefined) {
+            response.writeHead(400, {"Content-Type": "text/html"});
+            response.end("Bad request. Must include 'button' in query string!");
+            return;
+        }
+
+        let time = 200;
+        if (query.time !== undefined) {
+            const parsedTime = parseInt(query.time as string, 10);
+            if (parsedTime)
+                time = parsedTime;
+        }
+
+        const button = parseInt(query.button as string, 10);
+        if (ButtonType[button] === undefined) {
+            response.writeHead(400, {"Content-Type": "text/html"});
+            response.end("Bad request. Unknown button " + query.button);
+            return;
+        }
+
+        controller.pushButton(button);
+        setTimeout(() => controller.releaseButton(button), time);
+
+        response.writeHead(200, {"Content-Type": "text/html"});
+        response.end("OK");
+        return;
+    } else if (pathname === "listTargets") {
+        const targets = controller.targetConfigurations;
+
+        response.writeHead(200, {"Content-Type": "application/json"});
+        response.end(JSON.stringify(targets, undefined, 4));
+        return;
+    } else if (pathname === "setActive") {
+        if (query === undefined || query.active === undefined) {
+            response.writeHead(400, {"Content-Type": "text/html"});
+            response.end("Bad request. Must include 'active' in query string!");
+            return;
+        }
+
+        const str = (query.active as string).toLowerCase();
+        controller.active = str === "true" || str === "1";
+        response.writeHead(200, {"Content-Type": "text/html"});
+        response.end("OK");
+        return;
+    } else if (pathname === "getActive") {
+        response.writeHead(200, {"Content-Type": "text/html"});
+        response.end(controller.active? "true": "false");
+        return;
+    } else {
+        response.writeHead(404, {"Content-Type": "text/html"});
+        response.end("Not Found. No path found for " + pathname);
+        return;
+    }
+}).listen(8080);

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -142,6 +142,7 @@ export class Characteristic extends EventEmitter<Events> {
   static AudioFeedback: typeof HomeKitTypes.Generated.AudioFeedback;
   static BatteryLevel: typeof HomeKitTypes.Generated.BatteryLevel;
   static Brightness: typeof HomeKitTypes.Generated.Brightness;
+  static ButtonEvent: typeof HomeKitTypes.Remote.ButtonEvent;
   static CarbonDioxideDetected: typeof HomeKitTypes.Generated.CarbonDioxideDetected;
   static CarbonDioxideLevel: typeof HomeKitTypes.Generated.CarbonDioxideLevel;
   static CarbonDioxidePeakLevel: typeof HomeKitTypes.Generated.CarbonDioxidePeakLevel;
@@ -251,6 +252,7 @@ export class Characteristic extends EventEmitter<Events> {
   static SecuritySystemAlarmType: typeof HomeKitTypes.Generated.SecuritySystemAlarmType;
   static SecuritySystemCurrentState: typeof HomeKitTypes.Generated.SecuritySystemCurrentState;
   static SecuritySystemTargetState: typeof HomeKitTypes.Generated.SecuritySystemTargetState;
+  static SelectedAudioStreamConfiguration: typeof HomeKitTypes.Remote.SelectedAudioStreamConfiguration;
   /**
    * @deprecated Removed in iOS 11. Use SelectedRTPStreamConfiguration instead.
    */
@@ -260,7 +262,9 @@ export class Characteristic extends EventEmitter<Events> {
   static ServiceLabelIndex: typeof HomeKitTypes.Generated.ServiceLabelIndex;
   static ServiceLabelNamespace: typeof HomeKitTypes.Generated.ServiceLabelNamespace;
   static SetDuration: typeof HomeKitTypes.Generated.SetDuration;
+  static SetupDataStreamTransport: typeof HomeKitTypes.DataStream.SetupDataStreamTransport;
   static SetupEndpoints: typeof HomeKitTypes.Generated.SetupEndpoints;
+  static SiriInputType: typeof HomeKitTypes.Remote.SiriInputType;
   static SlatType: typeof HomeKitTypes.Generated.SlatType;
   static SleepDiscoveryMode: typeof HomeKitTypes.TV.SleepDiscoveryMode;
   static SmokeDetected: typeof HomeKitTypes.Generated.SmokeDetected;
@@ -273,11 +277,14 @@ export class Characteristic extends EventEmitter<Events> {
   static StreamingStatus: typeof HomeKitTypes.Generated.StreamingStatus;
   static SulphurDioxideDensity: typeof HomeKitTypes.Generated.SulphurDioxideDensity;
   static SupportedAudioStreamConfiguration: typeof HomeKitTypes.Generated.SupportedAudioStreamConfiguration;
+  static SupportedDataStreamTransportConfiguration: typeof HomeKitTypes.DataStream.SupportedDataStreamTransportConfiguration;
   static SupportedRTPConfiguration: typeof HomeKitTypes.Generated.SupportedRTPConfiguration;
   static SupportedVideoStreamConfiguration: typeof HomeKitTypes.Generated.SupportedVideoStreamConfiguration;
   static SwingMode: typeof HomeKitTypes.Generated.SwingMode;
   static TargetAirPurifierState: typeof HomeKitTypes.Generated.TargetAirPurifierState;
   static TargetAirQuality: typeof HomeKitTypes.Generated.TargetAirQuality;
+  static TargetControlList: typeof HomeKitTypes.Remote.TargetControlList;
+  static TargetControlSupportedConfiguration: typeof HomeKitTypes.Remote.TargetControlSupportedConfiguration;
   static TargetDoorState: typeof HomeKitTypes.Generated.TargetDoorState;
   static TargetFanState: typeof HomeKitTypes.Generated.TargetFanState;
   static TargetHeaterCoolerState: typeof HomeKitTypes.Generated.TargetHeaterCoolerState;

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -133,14 +133,14 @@ export type Events = {
     events: CharacteristicEvents,
     cb: NodeCallback<CharacteristicData[]>,
     remote: boolean,
-    connectionID: string,
+    session: Session,
   ) => void;
   [HAPServerEventTypes.SET_CHARACTERISTICS]: (
     data: CharacteristicData[],
     events: CharacteristicEvents,
     cb: NodeCallback<CharacteristicData[]>,
     remote: boolean,
-    connectionID: string,
+    session: Session,
   ) => void;
   [HAPServerEventTypes.SESSION_CLOSE]: (sessionID: string, events: CharacteristicEvents) => void;
   [HAPServerEventTypes.REQUEST_RESOURCE]: (data: Resource, cb: NodeCallback<Buffer>) => void;
@@ -886,7 +886,7 @@ export class HAPServer extends EventEmitter<Events> {
         // 207 "multi-status" is returned when an error occurs reading a characteristic. otherwise 200 is returned
         response.writeHead(errorOccurred? 207: 200, {"Content-Type": "application/hap+json"});
         response.end(JSON.stringify({characteristics: characteristics}));
-      }), false, session.sessionID);
+      }), false, session);
     } else if (request.method == "PUT") {
       if (!session.encryption) {
         if (!request.headers || (request.headers && request.headers["authorization"] !== this.accessoryInfo.pincode)) {
@@ -938,7 +938,7 @@ export class HAPServer extends EventEmitter<Events> {
           response.writeHead(204); // 204 "No content"
           response.end();
         }
-      }), false, session.sessionID);
+      }), false, session);
     }
   }
 

--- a/src/lib/HomeKitRemoteController.ts
+++ b/src/lib/HomeKitRemoteController.ts
@@ -1,0 +1,502 @@
+import * as tlv from './util/tlv';
+import bufferShim from "buffer-shims";
+import createDebug from 'debug';
+
+import { Service } from "./Service";
+import {
+    Characteristic,
+    CharacteristicEventTypes,
+    CharacteristicGetCallback,
+    CharacteristicSetCallback
+} from "./Characteristic";
+import { CharacteristicValue } from "../types";
+import { Status } from "./HAPServer";
+import { Accessory } from "./Accessory";
+
+const debug = createDebug('HomeKitRemoteController');
+
+export enum TargetControlCommands {
+    MAXIMUM_TARGETS = 0x01,
+    TICKS_PER_SECOND = 0x02,
+    SUPPORTED_BUTTON_CONFIGURATION = 0x03,
+    TYPE = 0x04
+}
+
+export enum SupportedButtonConfigurationTypes {
+    BUTTON_ID = 0x01,
+    BUTTON_TYPE = 0x02
+}
+
+export enum ButtonType {
+    UNDEFINED = 0x00,
+    MENU = 0x01,
+    PLAY_PAUSE = 0x02,
+    TV_HOME = 0x03,
+    SELECT = 0x04,
+    ARROW_UP = 0x05,
+    ARROW_RIGHT = 0x06,
+    ARROW_DOWN = 0x07,
+    ARROW_LEFT = 0x08,
+    VOLUME_UP = 0x09,
+    VOLUME_DOWN = 0x0A,
+    SIRI = 0x0B,
+    POWER = 0x0C,
+    GENERIC = 0x0D
+}
+
+
+export enum TargetControlList {
+    OPERATION = 0x01,
+    TARGET_CONFIGURATION = 0x02
+}
+
+export enum Operation {
+    UNDEFINED = 0x00,
+    LIST = 0x01,
+    ADD = 0x02,
+    REMOVE = 0x03,
+    RESET = 0x04,
+    UPDATE = 0x05
+}
+
+export enum TargetConfigurationTypes {
+    TARGET_IDENTIFIER = 0x01,
+    TARGET_NAME = 0x02,
+    TARGET_CATEGORY = 0x03,
+    BUTTON_CONFIGURATION = 0x04
+}
+
+export enum TargetCategory {
+    UNDEFINED = 0x00,
+    APPLE_TV = 0x18
+}
+
+export enum ButtonConfigurationTypes {
+    BUTTON_ID = 0x01,
+    BUTTON_TYPE = 0x02,
+    BUTTON_NAME = 0x03,
+}
+
+export enum ButtonEvent {
+    BUTTON_ID = 0x01,
+    BUTTON_STATE = 0x02,
+    TIMESTAMP = 0x03,
+    ACTIVE_IDENTIFIER = 0x04,
+}
+
+export enum ButtonState {
+    UP = 0x00,
+    DOWN = 0x01
+}
+
+
+export type SupportedConfiguration = {
+    maximumTargets: number,
+    ticksPerSecond: number,
+    supportedButtonConfiguration: SupportedButtonConfiguration[],
+    hardwareImplemented: boolean
+}
+
+export type SupportedButtonConfiguration = {
+    buttonID: number,
+    buttonType: ButtonType
+}
+
+export type TargetConfiguration = {
+    targetIdentifier: number,
+    targetName?: string, // on Operation.UPDATE targetName is left out
+    targetCategory?: TargetCategory, // on Operation.UPDATE targetCategory is left out
+    buttonConfiguration: ButtonConfiguration[]
+}
+
+export type ButtonConfiguration = {
+    buttonID: number,
+    buttonType: ButtonType,
+    buttonName?: string
+}
+
+export class HomeKitRemoteController {
+
+    targetControlManagementService?: Service;
+    targetControlService?: Service;
+
+    buttons: Record<number, number>;
+    supportedConfiguration: string;
+    // it is advice to persistently store this configuration below, but HomeKit seems to just reconfigure itself
+    // after an reboot of the accessory. If someone has the time to implement persistent storage
+    // 'activeIdentifier' and 'active' should probably be included as well
+    targetConfigurations: Record<number, TargetConfiguration>;
+    targetConfigurationsString: string;
+
+    lastButtonEvent: string;
+
+    activeIdentifier: number;
+    active: boolean;
+
+    constructor() {
+        this.buttons = {};
+        const configuration: SupportedConfiguration = this.constructSupportedConfiguration();
+        this.supportedConfiguration = this._targetControlSupportedConfiguration(configuration);
+        this.targetConfigurations = {};
+        this.targetConfigurationsString = "";
+
+        this.lastButtonEvent = "";
+
+        this.activeIdentifier = 0; // id of 0 means no device selected
+        this.active = false;
+
+        this._createServices();
+    }
+
+    pushButton = (button: ButtonType) => {
+        const timestamp = new Date().getTime();
+        this._buttonEvent(this.buttons[button], ButtonState.DOWN, timestamp, this.activeIdentifier);
+        debug("Pressed button %d", button);
+    };
+
+    releaseButton = (button: ButtonType) => {
+        const timestamp = new Date().getTime();
+        this._buttonEvent(this.buttons[button], ButtonState.UP, timestamp, this.activeIdentifier);
+        debug("Released button %d", button);
+    };
+
+    setActiveIdentifier = (activeIdentifier: number) => {
+        debug("%d is now active", activeIdentifier);
+        this.activeIdentifier = activeIdentifier;
+        this.targetControlService!.getCharacteristic(Characteristic.ActiveIdentifier)!.updateValue(activeIdentifier);
+    };
+
+    isConfigured = (targetIdentifier: number) => {
+        return this.targetConfigurations[targetIdentifier] !== undefined;
+    };
+
+    getTargetIdentifierByName = (name: string) => {
+        for (const activeIdentifier in this.targetConfigurations) {
+            const configuration = this.targetConfigurations[activeIdentifier];
+            if (configuration.targetName === name) {
+                return parseInt(activeIdentifier);
+            }
+        }
+        return undefined;
+    };
+
+    addServicesToAccessory = (accessory: Accessory) => {
+        if (!this.targetControlManagementService || !this.targetControlService) {
+            throw new Error("Services not configured!"); // playing it save
+        }
+
+        accessory.addService(this.targetControlManagementService);
+        accessory.setPrimaryService(this.targetControlManagementService);
+        accessory.addService(this.targetControlService);
+    };
+
+    constructSupportedConfiguration = () => {
+        const configuration: SupportedConfiguration = {
+            maximumTargets: 10, // some random number. (ten should be okay?)
+            ticksPerSecond: 1000, // we rely on unix timestamps
+            supportedButtonConfiguration: [],
+            hardwareImplemented: false // siri is only allowed for hardware implemented remotes
+        };
+
+        const supportedButtons = [ // siri button is left out
+            ButtonType.MENU, ButtonType.PLAY_PAUSE, ButtonType.TV_HOME, ButtonType.SELECT,
+            ButtonType.ARROW_UP, ButtonType.ARROW_RIGHT, ButtonType.ARROW_DOWN, ButtonType.ARROW_LEFT,
+            ButtonType.VOLUME_UP, ButtonType.VOLUME_DOWN, ButtonType.POWER, ButtonType.GENERIC
+        ];
+        supportedButtons.forEach(button => {
+            const buttonConfiguration: SupportedButtonConfiguration = {
+                buttonID: 100 + button,
+                buttonType: button
+            };
+            configuration.supportedButtonConfiguration.push(buttonConfiguration);
+            this.buttons[button] = buttonConfiguration.buttonID; // also saving mapping of type to id locally
+        });
+
+        return configuration;
+    };
+
+    _buttonEvent = (buttonID: number, buttonState: ButtonState, timestamp: number, activeIdentifier: number) => {
+        if (activeIdentifier === 0)
+            return; // cannot press button if no device is selected
+
+        const buttonIdTlv = tlv.encode(
+            ButtonEvent.BUTTON_ID, buttonID
+        );
+
+        const buttonStateTlv = tlv.encode(
+            ButtonEvent.BUTTON_STATE, buttonState
+        );
+
+        const timestampTlv = tlv.encode(
+            ButtonEvent.TIMESTAMP, tlv.writeUInt64(timestamp)
+            // timestamp should be uint64. bigint though is only supported by node 10.4.0 and above
+            // thus we just interpret timestamp as a regular number
+        );
+
+        const activeIdentifierTlv = tlv.encode(
+            ButtonEvent.ACTIVE_IDENTIFIER, tlv.writeUInt32(activeIdentifier)
+        );
+
+        this.lastButtonEvent = Buffer.concat([
+            buttonIdTlv, buttonStateTlv, timestampTlv, activeIdentifierTlv
+        ]).toString('base64');
+        this.targetControlService!.getCharacteristic(Characteristic.ButtonEvent)!.updateValue(this.lastButtonEvent);
+    };
+
+    _handleTargetControlWrite = (value: any, callback: CharacteristicSetCallback) => {
+        const data = bufferShim.from(value, 'base64');
+        const objects = tlv.decode(data);
+
+        const operation = objects[TargetControlList.OPERATION][0];
+
+        let targetConfiguration: TargetConfiguration | undefined = undefined;
+        if (objects[TargetControlList.TARGET_CONFIGURATION]) { // if target configuration was sent, parse it
+            targetConfiguration = this._parseTargetConfiguration(objects[TargetControlList.TARGET_CONFIGURATION]);
+        }
+
+        debug("Received TargetControl write operation %s%s", Operation[operation], targetConfiguration !== undefined
+            ? "with configuration: " + JSON.stringify(targetConfiguration)
+            : "");
+
+        if (targetConfiguration === undefined && (operation === Operation.ADD || operation === Operation.UPDATE || operation === Operation.REMOVE)) {
+            callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
+            return;
+        } else if (targetConfiguration && (operation === Operation.LIST || operation === Operation.RESET)) {
+            callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
+            return;
+        }
+
+        switch (operation) {
+            case Operation.ADD:
+                this.targetConfigurations[targetConfiguration!.targetIdentifier] = targetConfiguration!;
+
+                this.targetConfigurationsString = this._targetConfigurations(this.targetConfigurations);
+                break;
+            case Operation.UPDATE:
+                // update only seems to update button configuration, leaving out names and category
+                // for me it always removes the volume buttons from the configuration. Why, i don't know
+
+                const savedTargetConfiguration = this.targetConfigurations[targetConfiguration!.targetIdentifier];
+                if (targetConfiguration!.targetName)
+                    savedTargetConfiguration.targetName = targetConfiguration!.targetName;
+                if (targetConfiguration!.targetCategory)
+                    savedTargetConfiguration.targetCategory = targetConfiguration!.targetCategory;
+                if (targetConfiguration!.buttonConfiguration)
+                    savedTargetConfiguration.buttonConfiguration = targetConfiguration!.buttonConfiguration;
+
+                this.targetConfigurationsString = this._targetConfigurations(this.targetConfigurations);
+                break;
+            case Operation.REMOVE:
+                delete this.targetConfigurations[targetConfiguration!.targetIdentifier];
+
+                this.targetConfigurationsString = this._targetConfigurations(this.targetConfigurations);
+                break;
+            case Operation.RESET:
+                this.targetConfigurations = {};
+                this.targetConfigurationsString = "";
+                break;
+            case Operation.LIST:
+                this.targetConfigurationsString = this._targetConfigurations(this.targetConfigurations);
+                break;
+        }
+
+        callback(undefined, this.targetConfigurationsString); // passing value for write response
+        debug("Returning target configuration: " + this.targetConfigurationsString);
+
+        if (operation === Operation.ADD)
+            this.setActiveIdentifier(targetConfiguration!.targetIdentifier);
+    };
+
+    _parseTargetConfiguration = (data: Buffer) => {
+        const configTLV = tlv.decode(data);
+
+        const identifier = tlv.readUInt32(configTLV[TargetConfigurationTypes.TARGET_IDENTIFIER]);
+
+        let name = undefined;
+        if (configTLV[TargetConfigurationTypes.TARGET_NAME])
+            name = configTLV[TargetConfigurationTypes.TARGET_NAME].toString();
+
+        let category = undefined;
+        if (configTLV[TargetConfigurationTypes.TARGET_CATEGORY])
+            category = tlv.readUInt16(configTLV[TargetConfigurationTypes.TARGET_CATEGORY]);
+
+        const buttonConfiguration: ButtonConfiguration[] = [];
+
+        if (configTLV[TargetConfigurationTypes.BUTTON_CONFIGURATION]) {
+            const buttonConfigurationTLV = tlv.decodeList(configTLV[TargetConfigurationTypes.BUTTON_CONFIGURATION], ButtonConfigurationTypes.BUTTON_ID);
+            buttonConfigurationTLV.forEach(entry => {
+                const buttonId = entry[ButtonConfigurationTypes.BUTTON_ID][0];
+                const buttonType = tlv.readUInt16(entry[ButtonConfigurationTypes.BUTTON_TYPE]);
+                let buttonName;
+                if (entry[ButtonConfigurationTypes.BUTTON_NAME])
+                    buttonName = entry[ButtonConfigurationTypes.BUTTON_NAME].toString();
+
+                buttonConfiguration.push({
+                    buttonID: buttonId,
+                    buttonType: buttonType,
+                    buttonName: buttonName
+                })
+            });
+        }
+
+        return {
+            targetIdentifier: identifier,
+            targetName: name,
+            targetCategory: category,
+            buttonConfiguration: buttonConfiguration
+        } as TargetConfiguration;
+    };
+
+    _targetConfigurations = (configurations: Record<number, TargetConfiguration>) => {
+        const bufferList = [];
+        for (const key in configurations) {
+            // noinspection JSUnfilteredForInLoop
+            const configuration = configurations[key];
+
+            const targetIdentifier = tlv.encode(
+                TargetConfigurationTypes.TARGET_IDENTIFIER, tlv.writeUInt32(configuration.targetIdentifier)
+            );
+
+            const targetName = tlv.encode(
+                TargetConfigurationTypes.TARGET_NAME, configuration.targetName!
+            );
+
+            const targetCategory = tlv.encode(
+                TargetConfigurationTypes.TARGET_CATEGORY, tlv.writeUInt16(configuration.targetCategory!)
+            );
+
+            const buttonConfigurationBuffers: Buffer[] = [];
+            configuration.buttonConfiguration.forEach(value => {
+                let tlvBuffer = tlv.encode(
+                    ButtonConfigurationTypes.BUTTON_ID, value.buttonID,
+                    ButtonConfigurationTypes.BUTTON_TYPE, tlv.writeUInt16(value.buttonType)
+                );
+
+                if (value.buttonName) {
+                    tlvBuffer = Buffer.concat([
+                        tlvBuffer,
+                        tlv.encode(
+                            ButtonConfigurationTypes.BUTTON_NAME, value.buttonName
+                        )
+                    ])
+                }
+
+                buttonConfigurationBuffers.push(tlvBuffer);
+            });
+
+            const buttonConfiguration = tlv.encode(
+                TargetConfigurationTypes.BUTTON_CONFIGURATION, Buffer.concat(buttonConfigurationBuffers)
+            );
+
+            const targetConfiguration = Buffer.concat(
+                [targetIdentifier, targetName, targetCategory, buttonConfiguration]
+            );
+
+            bufferList.push(tlv.encode(TargetControlList.TARGET_CONFIGURATION, targetConfiguration));
+        }
+
+        return Buffer.concat(bufferList).toString('base64');
+    };
+
+    _targetControlSupportedConfiguration = (configuration: SupportedConfiguration) => {
+        const maximumTargets = tlv.encode(
+            TargetControlCommands.MAXIMUM_TARGETS, configuration.maximumTargets
+        );
+
+        const ticksPerSecond = tlv.encode(
+            TargetControlCommands.TICKS_PER_SECOND, tlv.writeUInt64(configuration.ticksPerSecond)
+        );
+
+        const supportedButtonConfigurationBuffers: Uint8Array[] = [];
+        configuration.supportedButtonConfiguration.forEach(value => {
+            const tlvBuffer = tlv.encode(
+                SupportedButtonConfigurationTypes.BUTTON_ID, value.buttonID,
+                SupportedButtonConfigurationTypes.BUTTON_TYPE, tlv.writeUInt16(value.buttonType)
+            );
+            supportedButtonConfigurationBuffers.push(tlvBuffer);
+        });
+        const supportedButtonConfiguration = tlv.encode(
+            TargetControlCommands.SUPPORTED_BUTTON_CONFIGURATION, Buffer.concat(supportedButtonConfigurationBuffers)
+        );
+
+        const type = tlv.encode(TargetControlCommands.TYPE, configuration.hardwareImplemented? 1: 0);
+
+        return Buffer.concat(
+            [maximumTargets, ticksPerSecond, supportedButtonConfiguration, type]
+        ).toString('base64');
+    };
+
+    _createServices = () => {
+        this.targetControlManagementService = new Service.TargetControlManagement('', '');
+        this.targetControlManagementService.getCharacteristic(Characteristic.TargetControlSupportedConfiguration)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(null, this.supportedConfiguration);
+            }).getValue();
+        this.targetControlManagementService.getCharacteristic(Characteristic.TargetControlList)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(null, this.targetConfigurationsString);
+            })
+            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                this._handleTargetControlWrite(value, callback);
+            }).getValue();
+
+        // you can also expose multiple TargetControl services to control multiple apple tvs simultaneously.
+        // should we extend this class to support multiple TargetControl services or should users just create a second accessory?
+        this.targetControlService = new Service.TargetControl('', '');
+        this.targetControlService.getCharacteristic(Characteristic.ActiveIdentifier)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(undefined, this.activeIdentifier);
+            }).getValue();
+        this.targetControlService.getCharacteristic(Characteristic.Active)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(undefined, this.active);
+            })
+            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                this.active = value as boolean;
+                callback();
+            }).getValue();
+        this.targetControlService.getCharacteristic(Characteristic.ButtonEvent)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(undefined, this.lastButtonEvent);
+            }).getValue();
+
+        /* The following characteristics are need for Siri support and the implementation of HomeKit Data Streams
+        const siriService = new Service.Siri('', '');
+        siriService.getCharacteristic(Characteristic.SiriInputType)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+               callback(undefined, 0); // push button triggered Apple TV
+            });
+
+        const dataStreamTransportManagement = new Service.DataStreamTransportManagement('', '');
+        dataStreamTransportManagement.getCharacteristic(Characteristic.SupportedDataStreamTransportConfiguration)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(undefined, "");
+            });
+        dataStreamTransportManagement.getCharacteristic(Characteristic.SetupDataStreamTransport)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(null, "");
+            })
+            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                const writeResponse = "";
+                callback(null, writeResponse);
+            }).getValue();
+        dataStreamTransportManagement.getCharacteristic(Characteristic.Version)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(undefined, "1.0");
+            });
+
+        const audioStreamManagement = new Service.AudioStreamManagement('', '');
+        audioStreamManagement.getCharacteristic(Characteristic.SupportedAudioStreamConfiguration)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(undefined, "");
+            });
+        audioStreamManagement.getCharacteristic(Characteristic.SelectedAudioStreamConfiguration)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(null, "");
+            })
+            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                callback();
+            }).getValue();
+        */
+    }
+}

--- a/src/lib/Service.ts
+++ b/src/lib/Service.ts
@@ -63,6 +63,7 @@ export class Service extends EventEmitter<Events> {
   static AccessoryInformation: typeof HomeKitTypes.Generated.AccessoryInformation;
   static AirPurifier: typeof HomeKitTypes.Generated.AirPurifier;
   static AirQualitySensor: typeof HomeKitTypes.Generated.AirQualitySensor;
+  static AudioStreamManagement: typeof HomeKitTypes.Remote.AudioStreamManagement;
   static BatteryService: typeof HomeKitTypes.Generated.BatteryService;
   static BridgeConfiguration: typeof HomeKitTypes.Bridged.BridgeConfiguration;
   static BridgingState: typeof HomeKitTypes.Bridged.BridgingState;
@@ -71,6 +72,7 @@ export class Service extends EventEmitter<Events> {
   static CarbonDioxideSensor: typeof HomeKitTypes.Generated.CarbonDioxideSensor;
   static CarbonMonoxideSensor: typeof HomeKitTypes.Generated.CarbonMonoxideSensor;
   static ContactSensor: typeof HomeKitTypes.Generated.ContactSensor;
+  static DataStreamTransportManagement: typeof HomeKitTypes.DataStream.DataStreamTransportManagement;
   static Door: typeof HomeKitTypes.Generated.Door;
   static Doorbell: typeof HomeKitTypes.Generated.Doorbell;
   static Fan: typeof HomeKitTypes.Generated.Fan;
@@ -101,12 +103,15 @@ export class Service extends EventEmitter<Events> {
   static Relay: typeof HomeKitTypes.Bridged.Relay;
   static SecuritySystem: typeof HomeKitTypes.Generated.SecuritySystem;
   static ServiceLabel: typeof HomeKitTypes.Generated.ServiceLabel;
+  static Siri: typeof HomeKitTypes.Remote.Siri;
   static Slat: typeof HomeKitTypes.Generated.Slat;
   static SmokeSensor: typeof HomeKitTypes.Generated.SmokeSensor;
   static Speaker: typeof HomeKitTypes.Generated.Speaker;
   static StatefulProgrammableSwitch: typeof HomeKitTypes.Bridged.StatefulProgrammableSwitch;
   static StatelessProgrammableSwitch: typeof HomeKitTypes.Generated.StatelessProgrammableSwitch;
   static Switch: typeof HomeKitTypes.Generated.Switch;
+  static TargetControl: typeof HomeKitTypes.Remote.TargetControl;
+  static TargetControlManagement: typeof HomeKitTypes.Remote.TargetControlManagement;
   static Television: typeof HomeKitTypes.TV.Television;
   static TelevisionSpeaker: typeof HomeKitTypes.TV.TelevisionSpeaker;
   static TemperatureSensor: typeof HomeKitTypes.Generated.TemperatureSensor;

--- a/src/lib/gen/HomeKit-DataStream.ts
+++ b/src/lib/gen/HomeKit-DataStream.ts
@@ -1,0 +1,68 @@
+// manually created
+
+import {Characteristic, Formats, Perms} from '../Characteristic';
+import {Service} from "../Service";
+
+
+/**
+ * Characteristic "Supported Data Stream Transport Configuration"
+ */
+
+export class SupportedDataStreamTransportConfiguration extends Characteristic {
+
+    static readonly UUID: string = '00000130-0000-1000-8000-0026BB765291';
+
+    constructor() {
+        super('Supported Data Stream Transport Configuration', SupportedDataStreamTransportConfiguration.UUID);
+        this.setProps({
+            format: Formats.TLV8,
+            perms: [Perms.PAIRED_READ]
+        });
+        this.value = this.getDefaultValue();
+    }
+
+}
+
+Characteristic.SupportedDataStreamTransportConfiguration = SupportedDataStreamTransportConfiguration;
+
+/**
+ * Characteristic "Setup Data Stream Transport"
+ */
+
+export class SetupDataStreamTransport extends Characteristic {
+
+    static readonly UUID: string = '00000131-0000-1000-8000-0026BB765291';
+
+    constructor() {
+        super('Setup Data Stream Transport', SetupDataStreamTransport.UUID);
+        this.setProps({
+            format: Formats.TLV8,
+            perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE, Perms.WRITE_RESPONSE]
+        });
+        this.value = this.getDefaultValue();
+    }
+
+}
+
+Characteristic.SetupDataStreamTransport = SetupDataStreamTransport;
+
+
+/**
+ * Service "Data Stream Transport Management"
+ */
+
+export class DataStreamTransportManagement extends Service {
+
+    static readonly UUID: string = '00000129-0000-1000-8000-0026BB765291';
+
+    constructor(displayName: string, subtype: string) {
+        super(displayName, DataStreamTransportManagement.UUID, subtype);
+
+        // Required Characteristics
+        this.addCharacteristic(Characteristic.SupportedDataStreamTransportConfiguration);
+        this.addCharacteristic(Characteristic.SetupDataStreamTransport);
+        this.addCharacteristic(Characteristic.Version);
+    }
+}
+
+Service.DataStreamTransportManagement = DataStreamTransportManagement;

--- a/src/lib/gen/HomeKit-Remote.ts
+++ b/src/lib/gen/HomeKit-Remote.ts
@@ -1,7 +1,7 @@
 // manually created
 
-import {Characteristic, Formats, Perms} from '../Characteristic';
-import {Service} from '../Service';
+import { Access, Characteristic, Formats, Perms } from '../Characteristic';
+import { Service } from '../Service';
 
 
 /**
@@ -39,6 +39,7 @@ export class TargetControlList extends Characteristic {
             perms: [Perms.PAIRED_WRITE, Perms.PAIRED_READ, Perms.WRITE_RESPONSE]
         });
         this.value = this.getDefaultValue();
+        this.accessRestrictedToAdmins = [Access.READ, Access.WRITE]
     }
 
 }
@@ -60,6 +61,7 @@ export class ButtonEvent extends Characteristic {
             perms: [Perms.PAIRED_READ, Perms.NOTIFY]
         });
         this.value = this.getDefaultValue();
+        this.accessRestrictedToAdmins = [Access.NOTIFY];
     }
 
 }

--- a/src/lib/gen/HomeKit-Remote.ts
+++ b/src/lib/gen/HomeKit-Remote.ts
@@ -1,0 +1,193 @@
+// manually created
+
+import {Characteristic, Formats, Perms} from '../Characteristic';
+import {Service} from '../Service';
+
+
+/**
+ * Characteristic "Target Control Supported Configuration"
+ */
+
+export class TargetControlSupportedConfiguration extends Characteristic {
+
+    static readonly UUID: string = '00000123-0000-1000-8000-0026BB765291';
+
+    constructor() {
+        super('Target Control Supported Configuration', TargetControlSupportedConfiguration.UUID);
+        this.setProps({
+            format: Formats.TLV8,
+            perms: [Perms.PAIRED_READ]
+        });
+        this.value = this.getDefaultValue();
+    }
+}
+
+Characteristic.TargetControlSupportedConfiguration = TargetControlSupportedConfiguration;
+
+/**
+ * Characteristic "Target Control List"
+ */
+
+export class TargetControlList extends Characteristic {
+
+    static readonly UUID: string = '00000124-0000-1000-8000-0026BB765291';
+
+    constructor() {
+        super('Target Control List', TargetControlList.UUID);
+        this.setProps({
+            format: Formats.TLV8,
+            perms: [Perms.PAIRED_WRITE, Perms.PAIRED_READ, Perms.WRITE_RESPONSE]
+        });
+        this.value = this.getDefaultValue();
+    }
+
+}
+
+Characteristic.TargetControlList = TargetControlList;
+
+/**
+ * Characteristic "Button Event"
+ */
+
+export class ButtonEvent extends Characteristic {
+
+    static readonly UUID: string = '00000126-0000-1000-8000-0026BB765291';
+
+    constructor() {
+        super('Button Event', ButtonEvent.UUID);
+        this.setProps({
+            format: Formats.TLV8,
+            perms: [Perms.PAIRED_READ, Perms.NOTIFY]
+        });
+        this.value = this.getDefaultValue();
+    }
+
+}
+
+Characteristic.ButtonEvent = ButtonEvent;
+
+/**
+ * Characteristic "Selected Audio Stream Configuration"
+ */
+
+export class SelectedAudioStreamConfiguration extends Characteristic {
+
+    static readonly UUID: string = '00000128-0000-1000-8000-0026BB765291';
+
+    constructor() {
+        super('Selected Audio Stream Configuration', SelectedAudioStreamConfiguration.UUID);
+        this.setProps({
+            format: Formats.TLV8,
+            perms: [Perms.PAIRED_READ, Perms.PAIRED_WRITE]
+        });
+        this.value = this.getDefaultValue();
+    }
+
+}
+
+Characteristic.SelectedAudioStreamConfiguration = SelectedAudioStreamConfiguration;
+
+/**
+ * Characteristic "Siri Input Type"
+ */
+
+export class SiriInputType extends Characteristic {
+
+    static readonly PUSH_BUTTON_TRIGGERED_APPLE_TV = 0;
+
+    static readonly UUID: string = '00000132-0000-1000-8000-0026BB765291';
+
+    constructor() {
+        super('Siri Input Type', SiriInputType.UUID);
+        this.setProps({
+            format: Formats.UINT8,
+            minValue: 0,
+            maxValue: 0,
+            validValues: [0],
+            perms: [Perms.PAIRED_READ]
+        });
+        this.value = this.getDefaultValue();
+    }
+
+}
+
+Characteristic.SiriInputType = SiriInputType;
+
+/**
+ * Service "Target Control Management"
+ */
+
+export class TargetControlManagement extends Service {
+
+    static readonly UUID: string = '00000122-0000-1000-8000-0026BB765291';
+
+    constructor(displayName: string, subtype: string) {
+        super(displayName, TargetControlManagement.UUID, subtype);
+
+        // Required Characteristics
+        this.addCharacteristic(Characteristic.TargetControlSupportedConfiguration);
+        this.addCharacteristic(Characteristic.TargetControlList);
+    }
+}
+
+Service.TargetControlManagement = TargetControlManagement;
+
+/**
+ * Service "Target Control"
+ */
+
+export class TargetControl extends Service {
+
+    static readonly UUID: string = '00000125-0000-1000-8000-0026BB765291';
+
+    constructor(displayName: string, subtype: string) {
+        super(displayName, TargetControl.UUID, subtype);
+
+        // Required Characteristics
+        this.addCharacteristic(Characteristic.ActiveIdentifier);
+        this.addCharacteristic(Characteristic.Active);
+        this.addCharacteristic(Characteristic.ButtonEvent);
+
+        // Optional Characteristics
+        this.addOptionalCharacteristic(Characteristic.Name);
+    }
+}
+
+Service.TargetControl = TargetControl;
+
+/**
+ * Service "Audio Stream Management"
+ */
+
+export class AudioStreamManagement extends Service {
+
+    static readonly UUID: string = '00000127-0000-1000-8000-0026BB765291';
+
+    constructor(displayName: string, subtype: string) {
+        super(displayName, AudioStreamManagement.UUID, subtype);
+
+        // Required Characteristics
+        this.addCharacteristic(Characteristic.SupportedAudioStreamConfiguration);
+        this.addCharacteristic(Characteristic.SelectedAudioStreamConfiguration);
+    }
+}
+
+Service.AudioStreamManagement = AudioStreamManagement;
+
+/**
+ * Service "Siri"
+ */
+
+export class Siri extends Service {
+
+    static readonly UUID: string = '00000133-0000-1000-8000-0026BB765291';
+
+    constructor(displayName: string, subtype: string) {
+        super(displayName, Siri.UUID, subtype);
+
+        // Required Characteristics
+        this.addCharacteristic(Characteristic.SiriInputType);
+    }
+}
+
+Service.Siri = Siri;

--- a/src/lib/gen/index.ts
+++ b/src/lib/gen/index.ts
@@ -1,8 +1,12 @@
 import * as gen from './HomeKit';
 import * as bridged from './HomeKit-Bridge';
 import * as tv from './HomeKit-TV';
+import * as remote from './HomeKit-Remote';
+import * as dataStream from './HomeKit-DataStream';
 
 export const Generated = gen;
 export const Bridged = bridged;
 export const TV = tv;
+export const Remote = remote;
+export const DataStream = dataStream;
 


### PR DESCRIPTION
This PR adds support for Apple TV Remote accessories (though without support for Siri commands).
As this PR relies on the changes made in #702 those commits are also included here. So that PR needs to be merged first. But I didn't want to wait. Although #702 is still in review, discussion can already be started for this PR.

The main API for remotes is in `src/lib/HomeKitRemoteController.ts` (with all new characteristics in `src/lib/gen/HomeKit-Remote.ts`).
For demonstration purposes I created `src/accessories/AppleTVRemote_accessory.ts`, which exposes an http api (documented in the source file) in order to play around with it.

As noted in `src/lib/HomeKitRemoteController.ts` line 126 ff. persistent storage of the target configuration is still not implemented (as I'm not quite sure how to handle plugins getting removed and added again in scenarios where for example homebridge is used). HomeKit seems to handle that fine though.

Issue regarding this topic: #612 

~ Andi