### PR TITLE
Publishing accessory type icons for pairing

### DIFF
--- a/src/Core.ts
+++ b/src/Core.ts
@@ -36,7 +36,9 @@ accessories.forEach((accessory) => {
     // @ts-ignore
     username: accessory.username,
     // @ts-ignore
-    pincode: accessory.pincode
+    pincode: accessory.pincode,
+    // @ts-ignore
+    category: accessory.category
   });
 });
 


### PR DESCRIPTION
Small change to allow overriding of the default type icon type which is displayed in the HomeKit pairing window. By default, accessories are published with the category type as "OTHER". This change will allow uses to override this type in their accessory code