### PR TITLE
init function - optional parameter storagePath

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export * from './lib/util/tlv';
 
 export * from './types';
 
-export function init(storagePath: string) {
+export function init(storagePath?: string) {
   // initialize our underlying storage system, passing on the directory if needed
   if (typeof storagePath !== 'undefined')
     storage.initSync({ dir: storagePath });


### PR DESCRIPTION
Checking the content of the init function I assume the parameter should be an optional.

~ Andi