### PR TITLE
Fixing session dictionary getting messed up handling multiple controllers of the same Apple ID

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -27,6 +27,7 @@ import {
 } from '../types';
 import { Camera } from './Camera';
 import { EventEmitter } from './EventEmitter';
+import { Session } from "./util/eventedhttp";
 
 // var HomeKitTypes = require('./gen/HomeKitTypes');
 // var RelayServer = require("./util/relayserver").RelayServer;
@@ -766,13 +767,13 @@ export class Accessory extends EventEmitter<Events> {
   }
 
 // called when a controller adds an additional pairing
-  _handleAddPairing = (controller: string, username: string, publicKey: Buffer, permission: PermissionTypes, callback: AddPairingCallback) => {
+  _handleAddPairing = (controller: Session, username: string, publicKey: Buffer, permission: PermissionTypes, callback: AddPairingCallback) => {
     if (!this._accessoryInfo) {
       callback(Codes.UNAVAILABLE);
       return;
     }
 
-    if (!this._accessoryInfo.hasAdminPermissions(controller)) {
+    if (!this._accessoryInfo.hasAdminPermissions(controller.username!)) {
       callback(Codes.AUTHENTICATION);
       return;
     }
@@ -794,13 +795,13 @@ export class Accessory extends EventEmitter<Events> {
     callback(0);
   };
 
-  _handleRemovePairing = (controller: string, username: string, callback: RemovePairingCallback) => {
+  _handleRemovePairing = (controller: Session, username: string, callback: RemovePairingCallback) => {
     if (!this._accessoryInfo) {
       callback(Codes.UNAVAILABLE);
       return;
     }
 
-    if (!this._accessoryInfo.hasAdminPermissions(controller)) {
+    if (!this._accessoryInfo.hasAdminPermissions(controller.username!)) {
       callback(Codes.AUTHENTICATION);
       return;
     }
@@ -815,13 +816,13 @@ export class Accessory extends EventEmitter<Events> {
     callback(0);
   };
 
-  _handleListPairings = (controller: string, callback: ListPairingsCallback) => {
+  _handleListPairings = (controller: Session, callback: ListPairingsCallback) => {
     if (!this._accessoryInfo) {
       callback(Codes.UNAVAILABLE);
       return;
     }
 
-    if (!this._accessoryInfo.hasAdminPermissions(controller)) {
+    if (!this._accessoryInfo.hasAdminPermissions(controller.username!)) {
       callback(Codes.AUTHENTICATION);
       return;
     }

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -124,9 +124,9 @@ export type Events = {
   [HAPServerEventTypes.IDENTIFY]: (cb: VoidCallback) => void;
   [HAPServerEventTypes.LISTENING]: (port: number) => void;
   [HAPServerEventTypes.PAIR]: (clientUsername: string, clientLTPK: Buffer, cb: VoidCallback) => void;
-  [HAPServerEventTypes.ADD_PAIRING]: (controller: string, username: string, publicKey: Buffer, permission: number, callback: PairingsCallback<void>) => void;
-  [HAPServerEventTypes.REMOVE_PAIRING]: (controller: string, username: string, callback: PairingsCallback<void>) => void;
-  [HAPServerEventTypes.LIST_PAIRINGS]: (controller: string, callback: PairingsCallback<PairingInformation[]>) => void;
+  [HAPServerEventTypes.ADD_PAIRING]: (controller: Session, username: string, publicKey: Buffer, permission: number, callback: PairingsCallback<void>) => void;
+  [HAPServerEventTypes.REMOVE_PAIRING]: (controller: Session, username: string, callback: PairingsCallback<void>) => void;
+  [HAPServerEventTypes.LIST_PAIRINGS]: (controller: Session, callback: PairingsCallback<PairingInformation[]>) => void;
   [HAPServerEventTypes.ACCESSORIES]: (cb: NodeCallback<Accessory[]>) => void;
   [HAPServerEventTypes.GET_CHARACTERISTICS]: (
     data: CharacteristicData[],
@@ -723,7 +723,7 @@ export class HAPServer extends EventEmitter<Events> {
       const publicKey = objects[TLVValues.PUBLIC_KEY];
       const permissions = objects[TLVValues.PERMISSIONS][0] as PermissionTypes;
 
-      this.emit(HAPServerEventTypes.ADD_PAIRING, session.username, identifier, publicKey, permissions, once((errorCode: number, data?: void) => {
+      this.emit(HAPServerEventTypes.ADD_PAIRING, session, identifier, publicKey, permissions, once((errorCode: number, data?: void) => {
         if (errorCode > 0) {
           debug("[%s] Pairings: failed ADD_PAIRING with code %d", this.accessoryInfo.username, errorCode);
           response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
@@ -738,7 +738,7 @@ export class HAPServer extends EventEmitter<Events> {
     } else if (method === Methods.REMOVE_PAIRING) {
       const identifier = objects[TLVValues.IDENTIFIER].toString();
 
-      this.emit(HAPServerEventTypes.REMOVE_PAIRING, session.username, identifier, once((errorCode: number, data?: void) => {
+      this.emit(HAPServerEventTypes.REMOVE_PAIRING, session, identifier, once((errorCode: number, data?: void) => {
         if (errorCode > 0) {
           debug("[%s] Pairings: failed REMOVE_PAIRING with code %d", this.accessoryInfo.username, errorCode);
           response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
@@ -751,7 +751,7 @@ export class HAPServer extends EventEmitter<Events> {
         debug("[%s] Pairings: successfully executed REMOVE_PAIRING", this.accessoryInfo.username);
       }));
     } else if (method === Methods.LIST_PAIRINGS) {
-      this.emit(HAPServerEventTypes.LIST_PAIRINGS, session.username, once((errorCode: number, data?: PairingInformation[]) => {
+      this.emit(HAPServerEventTypes.LIST_PAIRINGS, session, once((errorCode: number, data?: PairingInformation[]) => {
         if (errorCode > 0) {
           debug("[%s] Pairings: failed LIST_PAIRINGS with code %d", this.accessoryInfo.username, errorCode);
           response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});

--- a/src/lib/model/AccessoryInfo.ts
+++ b/src/lib/model/AccessoryInfo.ts
@@ -108,10 +108,10 @@ export class AccessoryInfo {
 
   /**
    * Remove a paired client from memory.
-   * @param controller - the username/identifier of the controller initiated the removal of the pairing
+   * @param controller - the session of the controller initiated the removal of the pairing
    * @param {string} username
    */
-  removePairedClient = (controller: string, username: string) => {
+  removePairedClient = (controller: Session, username: string) => {
     this._removePairedClient0(controller, username);
 
     if (this.pairedAdminClients === 0) { // if we don't have any admin clients left paired it is required to kill all normal clients
@@ -121,7 +121,7 @@ export class AccessoryInfo {
     }
   };
 
-  _removePairedClient0 = (controller: string, username: string) => {
+  _removePairedClient0 = (controller: Session, username: string) => {
     if (this.pairedClients[username] && this.pairedClients[username].permission === PermissionTypes.ADMIN)
       this.pairedAdminClients--;
     delete this.pairedClients[username];
@@ -135,14 +135,7 @@ export class AccessoryInfo {
       this.accessoryBagURL = "";
     }
 
-    const existingSession = Session.sessions[username];
-    if (existingSession) {
-      if (controller === username) {
-        existingSession.destroyConnectionAfterWrite();
-      } else {
-        existingSession.destroyConnection();
-      }
-    }
+    Session.destroyExistingConnectionsAfterUnpair(controller, username);
   };
 
   /**


### PR DESCRIPTION
Introduced with my PR in #702 the `sessions` variable in the Session class tracked all connected clients by the `username`. The `username` identifies every user connected to the home uniquely. As a result the `sessions` dictionary will get messed up with multiple Apple devices (from the same user/Apple ID) connecting and disconnecting from the HAP server.

Even though I knew that this id identifies every Apple ID connected to the home I messed that one up. Sorry for that. Here is the fix 😅

**Impact:**
To anyone who runs the current version and to clarify the impact. When you remove anybody from your home, the current HAP-NodeJS will have problems to kill any currently open connections from the user you are removing. Which means if devices from a persons in your home are currently connected to your HAP-NodeJS driven accessory, they may be able to still control your devices just after you remove the from your Home until their devices close the connection.
To workaround this issue just reboot your HAP-NodeJS instance after you removed the person.