### PR TITLE
Update Advertiser.ts

### DIFF
--- a/src/lib/Advertiser.ts
+++ b/src/lib/Advertiser.ts
@@ -56,7 +56,7 @@ export class Advertiser {
      */
     var host = this.accessoryInfo.username.replace(/\:/ig, "_") + '.local';
     var advertiseName = this.accessoryInfo.displayName
-      + "-"
+      + " "
       + crypto.createHash('sha512').update(this.accessoryInfo.username, 'utf8').digest('hex').slice(0, 4).toUpperCase();
 
     // create/recreate our advertisement


### PR DESCRIPTION
Small change to create more "commercial" like accessory advertising names in the HomeKit pairing window. Replaces '-' with ' '

before:
SomeAccessory-X1Y2

after:
SomeAccessory X1Y2