### PR TITLE
Update to protocol version 1.1.0

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -599,6 +599,9 @@ export class Accessory extends EventEmitter<Events> {
    *                                new Accessory.
    */
   publish = (info: PublishInfo, allowInsecureRequest?: boolean) => {
+    this.addService(Service.ProtocolInformation) // add the protocol information service to the primary accessory
+        .setCharacteristic(Characteristic.Version, Advertiser.protocolVersionService);
+
     // attempt to load existing AccessoryInfo from disk
     this._accessoryInfo = AccessoryInfo.load(info.username);
 

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -13,7 +13,7 @@ import {
   Perms
 } from './Characteristic';
 import { Advertiser } from './Advertiser';
-import { Codes, HAPServer, HAPServerEventTypes, Status } from './HAPServer';
+import { CharacteristicsWriteRequest, Codes, HAPServer, HAPServerEventTypes, Status } from './HAPServer';
 import { AccessoryInfo, PairingInformation, PermissionTypes } from './model/AccessoryInfo';
 import { IdentifierCache } from './model/IdentifierCache';
 import {
@@ -117,6 +117,12 @@ export type Resource = {
   'image-height': number;
   'image-width': number;
   'resource-type': ResourceTypes;
+}
+
+enum WriteRequestState {
+  REGULAR_REQUEST,
+  TIMED_WRITE_AUTHENTICATED,
+  TIMED_WRITE_REJECTED
 }
 
 type IdentifyCallback = VoidCallback;
@@ -965,12 +971,28 @@ export class Accessory extends EventEmitter<Events> {
 
 // Called when an iOS client wishes to change the state of this accessory - like opening a door, or turning on a light.
 // Or, to subscribe to change events for a particular Characteristic.
-  _handleSetCharacteristics = (data: CharacteristicData[], events: CharacteristicEvents, callback: HandleSetCharacteristicsCallback, remote: boolean, session: Session) => {
+  _handleSetCharacteristics = (writeRequest: CharacteristicsWriteRequest, events: CharacteristicEvents, callback: HandleSetCharacteristicsCallback, remote: boolean, session: Session) => {
+    const data = writeRequest.characteristics;
 
     // data is an array of characteristics and values like this:
     // [ { aid: 1, iid: 8, value: true, ev: true } ]
 
     debug("[%s] Processing characteristic set: %s", this.displayName, JSON.stringify(data));
+
+    let writeState: WriteRequestState = WriteRequestState.REGULAR_REQUEST;
+    if (writeRequest.pid !== undefined) { // check for timed writes
+      if (session.timedWritePid === writeRequest.pid) {
+        writeState = WriteRequestState.TIMED_WRITE_AUTHENTICATED;
+        clearTimeout(session.timedWriteTimeout!);
+        session.timedWritePid = undefined;
+        session.timedWriteTimeout = undefined;
+
+        debug("[%s] Timed write request got acknowledged for pid %d", this.displayName, writeRequest.pid);
+      } else {
+        writeState = WriteRequestState.TIMED_WRITE_REJECTED;
+        debug("[%s] TTL for timed write request has probably expired for pid %d", this.displayName, writeRequest.pid);
+      }
+    }
 
     // build up our array of responses to the characteristics requested asynchronously
     var characteristics: CharacteristicData[] = [];
@@ -999,6 +1021,19 @@ export class Accessory extends EventEmitter<Events> {
         if (characteristics.length === data.length)
           callback(null, characteristics);
 
+        return;
+      }
+
+      if (writeState === WriteRequestState.TIMED_WRITE_REJECTED) {
+        const response: any = {
+          aid: aid,
+          iid: iid
+        };
+        response[statusKey] = Status.INVALID_VALUE_IN_REQUEST;
+        characteristics.push(response);
+
+        if (characteristics.length === data.length)
+          callback(null, characteristics);
         return;
       }
 
@@ -1101,6 +1136,20 @@ export class Accessory extends EventEmitter<Events> {
               callback(null, characteristics);
             return;
           }
+        }
+
+        if (characteristic.props.perms.includes(Perms.TIMED_WRITE) && writeState !== WriteRequestState.TIMED_WRITE_AUTHENTICATED) {
+          debug('[%s] Tried writing to a timed write only Characteristic without properly preparing (iid of %s and aid of %s)', this.displayName, characteristicData.aid, characteristicData.iid);
+          const response: any = {
+            aid: aid,
+            iid: iid
+          };
+          response[statusKey] = Status.INVALID_VALUE_IN_REQUEST;
+          characteristics.push(response);
+
+          if (characteristics.length === data.length)
+            callback(null, characteristics);
+          return;
         }
 
         debug('[%s] Setting Characteristic "%s" to value %s', this.displayName, characteristic.displayName, value);

--- a/src/lib/Advertiser.ts
+++ b/src/lib/Advertiser.ts
@@ -15,6 +15,9 @@ import { AccessoryInfo } from './model/AccessoryInfo';
  */
 export class Advertiser {
 
+  static protocolVersion: string = "1.1";
+  static protocolVersionService: string = "1.1.0";
+
   _bonjourService: BonjourHap;
   _advertisement: Nullable<Service>;
   _setupHash: string;
@@ -34,7 +37,7 @@ export class Advertiser {
 
     var txtRecord = {
       md: this.accessoryInfo.displayName,
-      pv: "1.0",
+      pv: Advertiser.protocolVersion,
       id: this.accessoryInfo.username,
       "c#": this.accessoryInfo.configVersion + "", // "accessory conf" - represents the "configuration version" of an Accessory. Increasing this "version number" signals iOS devices to re-fetch /accessories data.
       "s#": "1", // "accessory state"
@@ -78,7 +81,7 @@ export class Advertiser {
 
       var txtRecord = {
         md: this.accessoryInfo.displayName,
-        pv: "1.0",
+        pv: Advertiser.protocolVersion,
         id: this.accessoryInfo.username,
         "c#": this.accessoryInfo.configVersion + "", // "accessory conf" - represents the "configuration version" of an Accessory. Increasing this "version number" signals iOS devices to re-fetch /accessories data.
         "s#": "1", // "accessory state"

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -106,6 +106,16 @@ export type HapRequest = {
   requestBody: any;
 }
 
+export type CharacteristicsWriteRequest = {
+  characteristics: CharacteristicData[],
+  pid?: number
+}
+
+export type PrepareWriteRequest = {
+  ttl: number,
+  pid: number
+}
+
 export enum HAPServerEventTypes {
   IDENTIFY = "identify",
   LISTENING = "listening",
@@ -136,7 +146,7 @@ export type Events = {
     session: Session,
   ) => void;
   [HAPServerEventTypes.SET_CHARACTERISTICS]: (
-    data: CharacteristicData[],
+    writeRequest: CharacteristicsWriteRequest,
     events: CharacteristicEvents,
     cb: NodeCallback<CharacteristicData[]>,
     remote: boolean,
@@ -217,6 +227,7 @@ export class HAPServer extends EventEmitter<Events> {
     '/pairings': '_handlePairings',
     '/accessories': '_handleAccessories',
     '/characteristics': '_handleCharacteristics',
+    '/prepare': '_prepareWrite',
     '/resource': '_handleResource'
   };
 
@@ -901,9 +912,10 @@ export class HAPServer extends EventEmitter<Events> {
         return;
       }
       // requestData is a JSON payload like { characteristics: [ { aid: 1, iid: 8, value: true, ev: true } ] }
-      var data = JSON.parse(requestData.toString()).characteristics as CharacteristicData[]; // pull out characteristics array
+      var writeRequest = JSON.parse(requestData.toString()) as CharacteristicsWriteRequest;
+      var data = writeRequest.characteristics; // pull out characteristics array
       // call out to listeners to retrieve the latest accessories JSON
-      this.emit(HAPServerEventTypes.SET_CHARACTERISTICS, data, events, once((err: Error, characteristics: CharacteristicData[]) => {
+      this.emit(HAPServerEventTypes.SET_CHARACTERISTICS, writeRequest, events, once((err: Error, characteristics: CharacteristicData[]) => {
         if (err) {
           debug("[%s] Error setting characteristics: %s", this.accessoryInfo.username, err.message);
           // rewrite characteristics array to include error status for each characteristic requested
@@ -941,6 +953,43 @@ export class HAPServer extends EventEmitter<Events> {
       }), false, session);
     }
   }
+
+  // Called when controller requests a timed write
+  _prepareWrite = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: { length: number; toString: () => string; }) => {
+    if (!this.allowInsecureRequest && !session.encryption) {
+      response.writeHead(470, {"Content-Type": "application/hap+json"});
+      response.end(JSON.stringify({status: Status.INSUFFICIENT_PRIVILEGES}));
+      return;
+    }
+
+    if (request.method == "PUT") {
+      if (requestData.length == 0) {
+        response.writeHead(400, {"Content-Type": "application/hap+json"});
+        response.end(JSON.stringify({status: Status.INVALID_VALUE_IN_REQUEST}));
+        return;
+      }
+
+      const data = JSON.parse(requestData.toString()) as PrepareWriteRequest;
+
+      if (data.pid && data.ttl) {
+        debug("[%s] Received prepare write request with pid %d and ttl %d", this.accessoryInfo.username, data.pid, data.ttl);
+
+        if (session.timedWriteTimeout) // clear any currently existing timeouts
+          clearTimeout(session.timedWriteTimeout);
+
+        session.timedWritePid = data.pid;
+        session.timedWriteTimeout = setTimeout(() => {
+          debug("[%s] Timed write request timed out for pid %d", this.accessoryInfo.username, data.pid);
+          session.timedWritePid = undefined;
+          session.timedWriteTimeout = undefined;
+        }, data.ttl);
+
+        response.writeHead(200, {"Content-Type": "application/hap+json"});
+        response.end(JSON.stringify({status: Status.SUCCESS}));
+        return;
+      }
+    }
+  };
 
   // Called when controller request snapshot
   _handleResource = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, requestData: { length: number; toString: () => string; }) => {

--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -149,6 +149,9 @@ export class Session {
   srpServer?: srp.Server;
   username?: string; // username is unique to every user in the home
 
+  timedWritePid?: number;
+  timedWriteTimeout?: NodeJS.Timeout;
+
   constructor(connection: EventedHTTPServerConnection) {
     this._connection = connection;
     this.sessionID = connection.sessionID;


### PR DESCRIPTION
This PR makes the following changes:

- The ProtocolInformation service gets added to the primary accessory
- The `/prepare` route got implemented to support prepared writes

<br>
Note:

I'm unsure what exactly the benefits are for prepared writes as no characteristics require it at this point. However I discovered that for lock services a HAP controller executes a prepared write when opening/closing. I don't know to which services this also applies.