### PR TITLE
HomeKit accessory types

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -70,7 +70,8 @@ export enum Categories {
   FAUCET = 29,
   SHOWER_HEAD = 30,
   TELEVISION = 31,
-  TARGET_CONTROLLER = 32 // Remote Control
+  TARGET_CONTROLLER = 32, // Remote Control
+  ROUTER = 33 // HomeKit enabled router
 }
 
 export enum AccessoryEventTypes {

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -64,6 +64,7 @@ export enum Categories {
   AIR_HUMIDIFIER = 22, //Not in HAP Spec
   AIR_DEHUMIDIFIER = 23, // Not in HAP Spec
   APPLE_TV = 24,
+  HOMEPOD = 25, // HomePod
   SPEAKER = 26,
   AIRPORT = 27,
   SPRINKLER = 28,


### PR DESCRIPTION
Discovered new HomeKit accessory type, #33, which appears as a router image in the HomeKit pairing window. This change defines type 33 as "ROUTER"

![IMG_1322](https://user-images.githubusercontent.com/19759130/67341846-66be2d00-f57c-11e9-8135-410849a14927.jpeg)
