### PR TITLE
Implemented the HomeKit Data Stream protocol

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export * from './lib/AccessoryLoader';
 export * from './lib/StreamController';
 export * from './lib/HAPServer';
 export * from './lib/gen';
+export * from './lib/datastream';
 
 export * from './lib/util/chacha20poly1305';
 export * from './lib/util/clone';

--- a/src/lib/datastream/DataStreamManagement.ts
+++ b/src/lib/datastream/DataStreamManagement.ts
@@ -1,0 +1,230 @@
+import * as tlv from '../util/tlv';
+import bufferShim from "buffer-shims";
+import createDebug from "debug";
+import {Service} from "../Service";
+import {
+    Characteristic,
+    CharacteristicEventTypes,
+    CharacteristicGetCallback,
+    CharacteristicSetCallback
+} from "../Characteristic";
+import {CharacteristicValue} from "../../types";
+import {DataStreamTransportManagement} from "../gen/HomeKit-DataStream";
+import {DataStreamServer, DataStreamServerEventMap, GlobalEventHandler, GlobalRequestHandler} from "./DataStreamServer";
+import {Session} from "../util/eventedhttp";
+import {Event} from "../EventEmitter";
+
+const debug = createDebug('DataStream:Management');
+
+export enum TransferTransportConfigurationTypes {
+    TRANSFER_TRANSPORT_CONFIGURATION = 1,
+}
+
+export enum TransportTypeTypes {
+    TRANSPORT_TYPE = 1,
+}
+
+
+export enum SetupDataStreamSessionTypes {
+    SESSION_COMMAND_TYPE = 1,
+    TRANSPORT_TYPE = 2,
+    CONTROLLER_KEY_SALT = 3,
+}
+
+export enum SetupDataStreamWriteResponseTypes {
+    STATUS = 1,
+    TRANSPORT_TYPE_SESSION_PARAMETERS = 2,
+    ACCESSORY_KEY_SALT = 3,
+}
+
+export enum TransportSessionConfiguration {
+    TCP_LISTENING_PORT = 1,
+}
+
+
+export enum TransportType {
+    HOMEKIT_DATA_STREAM = 0,
+}
+
+export enum SessionCommandType {
+    START_SESSION = 0,
+}
+
+export enum DataStreamStatus {
+    SUCCESS = 0,
+    GENERIC_ERROR = 1,
+    BUSY = 2, // maximum numbers of sessions
+}
+
+
+export class DataStreamManagement {
+
+    // one server per accessory is probably the best practice
+    private readonly dataStreamServer: DataStreamServer = new DataStreamServer();
+
+    dataStreamTransportManagementService: DataStreamTransportManagement;
+
+    supportedDataStreamTransportConfiguration: string;
+    lastSetupDataStreamTransportResponse: string = ""; // stripped. excludes ACCESSORY_KEY_SALT
+
+    constructor() {
+        const supportedConfiguration: TransportType[] = [TransportType.HOMEKIT_DATA_STREAM];
+        this.supportedDataStreamTransportConfiguration = this.buildSupportedDataStreamTransportConfigurationTLV(supportedConfiguration);
+
+
+        this.dataStreamTransportManagementService = this.setupService();
+    }
+
+    /**
+     * @returns the DataStreamTransportManagement service
+     */
+    getService(): DataStreamTransportManagement {
+        return this.dataStreamTransportManagementService;
+    }
+
+    /**
+     * Registers a new event handler to handle incoming event messages.
+     * The handler is only called for a connection if for the give protocol no ProtocolHandler
+     * was registered on the connection level.
+     *
+     * @param protocol {string | Protocols} - name of the protocol to register the handler for
+     * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
+     * @param handler {GlobalEventHandler} - function to be called for every occurring event
+     */
+    onEventMessage(protocol: string, event: string, handler: GlobalEventHandler): this {
+        this.dataStreamServer.onEventMessage(protocol, event, handler);
+        return this;
+    }
+
+    /**
+     * Removes an registered event handler.
+     *
+     * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
+     * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
+     * @param handler {GlobalEventHandler} - registered event handler
+     */
+    removeEventHandler(protocol: string, event: string, handler: GlobalEventHandler): this {
+        this.dataStreamServer.removeEventHandler(protocol, event, handler);
+        return this;
+    }
+
+    /**
+     * Registers a new request handler to handle incoming request messages.
+     * The handler is only called for a connection if for the give protocol no ProtocolHandler
+     * was registered on the connection level.
+     *
+     * @param protocol {string | Protocols} - name of the protocol to register the handler for
+     * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
+     * @param handler {GlobalRequestHandler} - function to be called for every occurring request
+     */
+    onRequestMessage(protocol: string, request: string, handler: GlobalRequestHandler): this {
+        this.dataStreamServer.onRequestMessage(protocol, request, handler);
+        return this;
+    }
+
+    /**
+     * Removes an registered request handler.
+     *
+     * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
+     * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
+     * @param handler {GlobalRequestHandler} - registered request handler
+     */
+    removeRequestHandler(protocol: string, request: string, handler: GlobalRequestHandler): this {
+        this.dataStreamServer.removeRequestHandler(protocol, request, handler);
+        return this;
+    }
+
+    /**
+     * Forwards any event listener for an DataStreamServer event to the DataStreamServer instance
+     *
+     * @param event - the event to register for
+     * @param listener - the event handler
+     */
+    onServerEvent(event: Event<keyof DataStreamServerEventMap>, listener: DataStreamServerEventMap[Event<keyof DataStreamServerEventMap>]): this {
+        this.dataStreamServer.on(event, listener);
+        return this;
+    }
+
+    private handleSetupDataStreamTransportWrite(value: any, callback: CharacteristicSetCallback, connectionID?: string) {
+        const data = bufferShim.from(value, 'base64');
+        const objects = tlv.decode(data);
+
+        const sessionCommandType = objects[SetupDataStreamSessionTypes.SESSION_COMMAND_TYPE][0];
+        const transportType = objects[SetupDataStreamSessionTypes.TRANSPORT_TYPE][0];
+        const controllerKeySalt = objects[SetupDataStreamSessionTypes.CONTROLLER_KEY_SALT];
+
+        debug("Received setup write with command %s and transport type %s", SessionCommandType[sessionCommandType], TransportType[transportType]);
+
+        if (sessionCommandType === SessionCommandType.START_SESSION) {
+            if (transportType !== TransportType.HOMEKIT_DATA_STREAM) {
+                callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
+                return;
+            }
+
+            if (!connectionID) { // we need the session for the shared secret to generate the encryption keys
+                callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
+                return;
+            }
+
+            const session: Session = Session.getSession(connectionID);
+            if (!session) { // we need the session for the shared secret to generate the encryption keys
+                callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
+                return;
+            }
+
+            this.dataStreamServer.prepareSession(session, controllerKeySalt, preparedSession => {
+                const listeningPort = tlv.encode(TransportSessionConfiguration.TCP_LISTENING_PORT, tlv.writeUInt16(preparedSession.port!));
+
+                let response: Buffer = Buffer.concat([
+                    tlv.encode(SetupDataStreamWriteResponseTypes.STATUS, DataStreamStatus.SUCCESS),
+                    tlv.encode(SetupDataStreamWriteResponseTypes.TRANSPORT_TYPE_SESSION_PARAMETERS, listeningPort)
+                ]);
+                this.lastSetupDataStreamTransportResponse = response.toString('base64'); // save last response without accessory key salt
+
+                response = Buffer.concat([
+                    response,
+                    tlv.encode(SetupDataStreamWriteResponseTypes.ACCESSORY_KEY_SALT, preparedSession.accessoryKeySalt)
+                ]);
+                callback(null, response.toString('base64'));
+            });
+        } else {
+            callback(null, DataStreamManagement.buildSetupStatusResponse(DataStreamStatus.GENERIC_ERROR));
+            return;
+        }
+    }
+
+    private static buildSetupStatusResponse(status: DataStreamStatus) {
+        return tlv.encode(SetupDataStreamWriteResponseTypes.STATUS, status).toString('base64');
+    }
+
+    private buildSupportedDataStreamTransportConfigurationTLV(supportedConfiguration: TransportType[]): string {
+        const buffers: Buffer[] = [];
+        supportedConfiguration.forEach(type => {
+           const transportType = tlv.encode(TransportTypeTypes.TRANSPORT_TYPE, type);
+           const transferTransportConfiguration = tlv.encode(TransferTransportConfigurationTypes.TRANSFER_TRANSPORT_CONFIGURATION, transportType);
+
+           buffers.push(transferTransportConfiguration);
+        });
+
+        return Buffer.concat(buffers).toString('base64');
+    }
+
+    private setupService(): DataStreamTransportManagement {
+        const dataStreamTransportManagement = new Service.DataStreamTransportManagement('', '');
+        dataStreamTransportManagement.getCharacteristic(Characteristic.SupportedDataStreamTransportConfiguration)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(undefined, this.supportedDataStreamTransportConfiguration);
+            }).getValue();
+        dataStreamTransportManagement.getCharacteristic(Characteristic.SetupDataStreamTransport)!
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(null, this.lastSetupDataStreamTransportResponse);
+            })
+            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback, context?: any, connectionID?: string) => {
+                this.handleSetupDataStreamTransportWrite(value, callback, connectionID);
+            }).getValue();
+        dataStreamTransportManagement.setCharacteristic(Characteristic.Version, DataStreamServer.version);
+
+        return dataStreamTransportManagement;
+    }
+
+}

--- a/src/lib/datastream/DataStreamParser.ts
+++ b/src/lib/datastream/DataStreamParser.ts
@@ -1,0 +1,901 @@
+import * as uuid from '../util/uuid'
+import * as encryption from "../util/encryption"
+import assert from 'assert';
+import createDebug from 'debug';
+
+// welcome to hell :)
+// in this file lies madness and frustration. and its not only about HDS. also JavaScript is hell
+
+const debug = createDebug("DataStream:Parser");
+
+class Magics {
+    static readonly TERMINATOR = { type: "terminator" };
+}
+
+export class ValueWrapper<T> { // basically used to differentiate between different sized integers when encoding (to force certain encoding)
+
+    value: T;
+
+    constructor(value: T) {
+        this.value = value;
+    }
+
+    public equals(obj: ValueWrapper<T>) : boolean {
+        return this.constructor.name === obj.constructor.name && obj.value === this.value;
+    }
+
+}
+
+export class Int8 extends ValueWrapper<number> {}
+export class Int16 extends ValueWrapper<number> {}
+export class Int32 extends ValueWrapper<number> {}
+export class Int64 extends ValueWrapper<number> {}
+export class Float32 extends ValueWrapper<number> {}
+export class Float64 extends ValueWrapper<number> {}
+export class SecondsSince2001 extends ValueWrapper<number> {}
+export class UUID extends ValueWrapper<string> {
+
+    constructor(value: string) {
+        assert(uuid.isValid(value), "invalid uuid format");
+        super(value);
+    }
+
+}
+
+export enum DataFormatTags {
+    INVALID = 0x00,
+
+    TRUE = 0x01,
+    FALSE = 0x02,
+
+    TERMINATOR = 0x03,
+    NULL = 0x04,
+    UUID = 0x05,
+    DATE = 0x06,
+
+    INTEGER_MINUS_ONE = 0x07,
+    INTEGER_RANGE_START_0 = 0x08,
+    INTEGER_RANGE_STOP_39 = 0x2E,
+    INT8 = 0x30,
+    INT16LE = 0x31,
+    INT32LE = 0x32,
+    INT64LE = 0x33,
+
+    FLOAT32LE = 0x35,
+    FLOAT64LE = 0x36,
+
+    UTF8_LENGTH_START = 0x40,
+    UTF8_LENGTH_STOP = 0x60,
+    UTF8_LENGTH8 = 0x61,
+    UTF8_LENGTH16LE = 0x62,
+    UTF8_LENGTH32LE = 0x63,
+    UTF8_LENGTH64LE = 0x64,
+    UTF8_NULL_TERMINATED = 0x6F,
+
+    DATA_LENGTH_START = 0x70,
+    DATA_LENGTH_STOP = 0x90,
+    DATA_LENGTH8 = 0x91,
+    DATA_LENGTH16LE = 0x92,
+    DATA_LENGTH32LE = 0x93,
+    DATA_LENGTH64LE = 0x94,
+    DATA_TERMINATED = 0x9F,
+
+    DEDUPLICATION_START = 0xA0,
+    DEDUPLICATION_STOP = 0xCF,
+
+    ARRAY_LENGTH_START = 0xD0,
+    ARRAY_LENGTH_STOP = 0xDE,
+    ARRAY_TERMINATED = 0xDF,
+
+    DICTIONARY_LENGTH_START = 0xE0,
+    DICTIONARY_LENGTH_STOP = 0xEE,
+    DICTIONARY_TERMINATED = 0xEF,
+}
+
+export namespace DataStreamParser {
+
+    export function decode(buffer: DataStreamReader): any {
+        const tag = buffer.readTag();
+
+        if (tag === DataFormatTags.INVALID) {
+            throw new Error("HDSDecoder: zero tag detected on index " + buffer.readerIndex);
+        } else if (tag === DataFormatTags.TRUE) {
+            return buffer.readTrue();
+        } else if (tag === DataFormatTags.FALSE) {
+            return buffer.readFalse();
+        } else if (tag === DataFormatTags.TERMINATOR) {
+            return Magics.TERMINATOR;
+        } else if (tag === DataFormatTags.NULL) {
+            return null;
+        } else if (tag === DataFormatTags.UUID) {
+            return buffer.readUUID();
+        } else if (tag === DataFormatTags.DATE) {
+            return buffer.readSecondsSince2001_01_01();
+        } else if (tag === DataFormatTags.INTEGER_MINUS_ONE) {
+            return buffer.readNegOne();
+        } else if (tag >= DataFormatTags.INTEGER_RANGE_START_0 && tag <= DataFormatTags.INTEGER_RANGE_STOP_39) {
+            return buffer.readIntRange(tag); // integer values from 0-39
+        } else if (tag === DataFormatTags.INT8) {
+            return buffer.readInt8();
+        } else if (tag === DataFormatTags.INT16LE) {
+            return buffer.readInt16LE();
+        } else if (tag === DataFormatTags.INT32LE) {
+            return buffer.readInt32LE();
+        } else if (tag === DataFormatTags.INT64LE) {
+            return buffer.readInt64LE();
+        } else if (tag === DataFormatTags.FLOAT32LE) {
+            return buffer.readFloat32LE();
+        } else if (tag === DataFormatTags.FLOAT64LE) {
+            return buffer.readFloat64LE();
+        } else if (tag >= DataFormatTags.UTF8_LENGTH_START && tag <= DataFormatTags.UTF8_LENGTH_STOP) {
+            const length = tag - DataFormatTags.UTF8_LENGTH_START;
+            return buffer.readUTF8(length);
+        } else if (tag === DataFormatTags.UTF8_LENGTH8) {
+            return buffer.readUTF8_Length8();
+        } else if (tag === DataFormatTags.UTF8_LENGTH16LE) {
+            return buffer.readUTF8_Length16LE();
+        } else if (tag === DataFormatTags.UTF8_LENGTH32LE) {
+            return buffer.readUTF8_Length32LE();
+        } else if (tag === DataFormatTags.UTF8_LENGTH64LE) {
+            return buffer.readUTF8_Length64LE();
+        } else if (tag === DataFormatTags.UTF8_NULL_TERMINATED) {
+            return buffer.readUTF8_NULL_terminated();
+        } else if (tag >= DataFormatTags.DATA_LENGTH_START && tag <= DataFormatTags.DATA_LENGTH_STOP) {
+            const length = tag - DataFormatTags.DATA_LENGTH_START;
+            buffer.readData(length);
+        } else if (tag === DataFormatTags.DATA_LENGTH8) {
+            return buffer.readData_Length8();
+        } else if (tag === DataFormatTags.DATA_LENGTH16LE) {
+            return buffer.readData_Length16LE();
+        } else if (tag === DataFormatTags.DATA_LENGTH32LE) {
+            return buffer.readData_Length32LE();
+        } else if (tag === DataFormatTags.DATA_LENGTH64LE) {
+            return buffer.readData_Length64LE();
+        } else if (tag === DataFormatTags.DATA_TERMINATED) {
+            return buffer.readData_terminated();
+        } else if (tag >= DataFormatTags.DEDUPLICATION_START && tag <= DataFormatTags.DEDUPLICATION_STOP) {
+            const index = tag - DataFormatTags.DEDUPLICATION_START;
+            return buffer.deduplicateData(index);
+        } else if (tag >= DataFormatTags.ARRAY_LENGTH_START && tag <= DataFormatTags.ARRAY_LENGTH_STOP) {
+            const length = tag - DataFormatTags.ARRAY_LENGTH_START;
+            const array = [];
+
+            for (let i = 0; i < length; i++) {
+                array.push(decode(buffer));
+            }
+
+            return array;
+        } else if (tag === DataFormatTags.ARRAY_TERMINATED) {
+            const array = [];
+
+            let element;
+            while ((element = decode(buffer)) != Magics.TERMINATOR) {
+                array.push(element);
+            }
+
+            return array;
+        } else if (tag >= DataFormatTags.DICTIONARY_LENGTH_START && tag <= DataFormatTags.DICTIONARY_LENGTH_STOP) {
+            const length = tag - DataFormatTags.DICTIONARY_LENGTH_START;
+            const dictionary: Record<any, any> = {};
+
+            for (let i = 0; i < length; i++) {
+                const key = decode(buffer);
+                dictionary[key] = decode(buffer);
+            }
+
+            return dictionary;
+        } else if (tag === DataFormatTags.DICTIONARY_TERMINATED) {
+            const dictionary: Record<any, any> = {};
+
+            let key;
+            while ((key = decode(buffer)) != Magics.TERMINATOR) {
+                dictionary[key] = decode(buffer); // decode value
+            }
+
+            return dictionary;
+        } else {
+            throw new Error("HDSDecoder: encountered unknown tag on index " + buffer.readerIndex + ": " + tag.toString(16));
+        }
+    }
+
+    export function encode(data: any, buffer: DataStreamWriter): void {
+        if (data === undefined) {
+            throw new Error("HDSEncoder: cannot encode undefined");
+        }
+
+        if (data === null) {
+            buffer.writeTag(DataFormatTags.NULL);
+            return;
+        }
+
+        switch (typeof data) {
+            case "boolean":
+                if (data) {
+                    buffer.writeTrue();
+                } else {
+                    buffer.writeFalse();
+                }
+                break;
+            case "number":
+                if (Number.isInteger(data)) {
+                    buffer.writeNumber(data);
+                } else {
+                    buffer.writeFloat64LE(new Float64(data));
+                }
+                break;
+            case "string":
+                buffer.writeUTF8(data);
+                break;
+            case "object":
+                if (Array.isArray(data)) {
+                    const length = data.length;
+
+                    if (length <= 12) {
+                        buffer.writeTag(DataFormatTags.ARRAY_LENGTH_START + length);
+                    } else {
+                        buffer.writeTag(DataFormatTags.ARRAY_TERMINATED);
+                    }
+
+                    data.forEach(element => {
+                        encode(element, buffer);
+                    });
+
+                    if (length > 12) {
+                        buffer.writeTag(DataFormatTags.TERMINATOR);
+                    }
+                } else if (data instanceof ValueWrapper) {
+                    if (data instanceof Int8) {
+                        buffer.writeInt8(data);
+                    } else if (data instanceof Int16) {
+                        buffer.writeInt16LE(data);
+                    } else if (data instanceof Int32) {
+                        buffer.writeInt32LE(data);
+                    } else if (data instanceof Int64) {
+                        buffer.writeInt64LE(data);
+                    } else if (data instanceof Float32) {
+                        buffer.writeFloat32LE(data);
+                    } else if (data instanceof Float64) {
+                        buffer.writeFloat64LE(data);
+                    } else if (data instanceof SecondsSince2001) {
+                        buffer.writeSecondsSince2001_01_01(data);
+                    } else if (data instanceof UUID) {
+                        buffer.writeUUID(data.value);
+                    } else {
+                        throw new Error("Unknown wrapped object 'ValueWrapper' of class " + data.constructor.name);
+                    }
+                } else if (data instanceof Buffer) {
+                    buffer.writeData(data);
+                } else { // object is treated as dictionary
+                    const entries = Object.entries(data);
+
+                    if (entries.length <= 14) {
+                        buffer.writeTag(DataFormatTags.DICTIONARY_LENGTH_START + entries.length);
+                    } else {
+                        buffer.writeTag(DataFormatTags.DICTIONARY_TERMINATED);
+                    }
+
+                    entries.forEach(entry => {
+                        encode(entry[0], buffer); // encode key
+                        encode(entry[1], buffer); // encode value
+                    });
+
+                    if (entries.length > 14) {
+                        buffer.writeTag(DataFormatTags.TERMINATOR);
+                    }
+                }
+                break;
+            default:
+                throw new Error("HDSEncoder: no idea how to encode value of type '" + (typeof data) +"': " + data);
+        }
+    }
+
+}
+
+export class DataStreamReader {
+
+    private readonly data: Buffer;
+    readerIndex: number;
+
+    private deduplicationData: any[] = [];
+
+    constructor(data: Buffer) {
+        this.data = data;
+        this.readerIndex = 0;
+    }
+
+    finished() {
+        if (this.readerIndex < this.data.length) {
+            const remainingHex = this.data.slice(this.readerIndex, this.data.length).toString("hex");
+            debug("WARNING Finished reading HDS stream, but there are still %d bytes remaining () %s", this.data.length - this.readerIndex, remainingHex);
+        }
+    }
+
+    deduplicateData(index: number) {
+        if (index >= this.deduplicationData.length) {
+            throw new Error("HDSDecoder: Tried deduplication of data for an index out of range (index " + index + " and got " + this.deduplicationData.length + " elements)");
+        }
+
+        return this.deduplicationData[index];
+    }
+
+    private cache(data: any) {
+        this.deduplicationData.push(data);
+        return data;
+    }
+
+    private ensureLength(bytes: number) {
+        if (this.readerIndex + bytes > this.data.length) {
+            const remaining = this.data.length - this.readerIndex;
+            throw new Error("HDSDecoder: End of data stream. Tried reading " + bytes + " bytes however got only " + remaining + " remaining!");
+        }
+    }
+
+    readTag() {
+        this.ensureLength(1);
+        return this.data.readUInt8(this.readerIndex++);
+    }
+
+    readTrue() {
+        return this.cache(true); // do those tag encoded values get cached?
+    }
+
+    readFalse() {
+        return this.cache(false);
+    }
+
+    readNegOne() {
+        return this.cache(-1);
+    }
+
+    readIntRange(tag: number) {
+        return this.cache(tag - DataFormatTags.INTEGER_RANGE_START_0); // integer values from 0-39
+    }
+
+    readInt8() {
+        this.ensureLength(1);
+        return this.cache(this.data.readInt8(this.readerIndex++));
+    }
+
+    readInt16LE() {
+        this.ensureLength(2);
+        const value = this.data.readInt16LE(this.readerIndex);
+        this.readerIndex += 2;
+        return this.cache(value);
+    }
+
+    readInt32LE() {
+        this.ensureLength(4);
+        const value = this.data.readInt32LE(this.readerIndex);
+        this.readerIndex += 4;
+        return this.cache(value);
+    }
+
+    readInt64LE() {
+        this.ensureLength(8);
+
+        const low = this.data.readInt32LE(this.readerIndex);
+        let value = this.data.readInt32LE(this.readerIndex + 4) * 0x100000000 + low;
+        if (low < 0) {
+            value += 0x100000000;
+        }
+
+        this.readerIndex += 8;
+        return this.cache(value);
+    }
+
+    readFloat32LE() {
+        this.ensureLength(4);
+        const value = this.data.readFloatLE(this.readerIndex);
+        this.readerIndex += 4;
+        return this.cache(value);
+    }
+
+    readFloat64LE() {
+        this.ensureLength(8);
+        const value = this.data.readDoubleLE(this.readerIndex);
+        return this.cache(value);
+    }
+
+    private readLength8() {
+        this.ensureLength(1);
+        return this.data.readUInt8(this.readerIndex++);
+    }
+
+    private readLength16LE() {
+        this.ensureLength(2);
+        const value = this.data.readUInt16LE(this.readerIndex);
+        this.readerIndex += 2;
+        return value;
+    }
+
+    private readLength32LE() {
+        this.ensureLength(4);
+        const value = this.data.readUInt32LE(this.readerIndex);
+        this.readerIndex += 4;
+        return value;
+    }
+
+    private readLength64LE() {
+        this.ensureLength(8);
+
+        const low = this.data.readUInt32LE(this.readerIndex);
+        const value = this.data.readUInt32LE(this.readerIndex + 4) * 0x100000000 + low;
+
+        this.readerIndex += 8;
+        return value;
+    }
+
+    readUTF8(length: number) {
+        this.ensureLength(length);
+        const value = this.data.toString('utf8', this.readerIndex, this.readerIndex + length);
+        this.readerIndex += length;
+        return this.cache(value);
+    }
+
+    readUTF8_Length8() {
+        const length = this.readLength8();
+        return this.readUTF8(length);
+    }
+
+    readUTF8_Length16LE() {
+        const length = this.readLength16LE();
+        return this.readUTF8(length);
+    }
+
+    readUTF8_Length32LE() {
+        const length = this.readLength32LE();
+        return this.readUTF8(length);
+    }
+
+    readUTF8_Length64LE() {
+        const length = this.readLength64LE();
+        return this.readUTF8(length);
+    }
+
+    readUTF8_NULL_terminated() {
+        let offset = this.readerIndex;
+        let nextByte;
+
+        for (;;) {
+            nextByte = this.data[offset];
+
+            if (nextByte === undefined) {
+                throw new Error("HDSDecoder: Reached end of data stream while reading NUL terminated string!");
+            } else  if (nextByte === 0) {
+                break;
+            } else {
+                offset++;
+            }
+        }
+
+        const value = this.data.toString('utf8', this.readerIndex, offset);
+        this.readerIndex = offset + 1;
+        return this.cache(value);
+    }
+
+    readData(length: number) {
+        this.ensureLength(length);
+        const value = this.data.slice(this.readerIndex, this.readerIndex + length);
+        this.readerIndex += length;
+
+        return this.cache(value);
+    }
+
+    readData_Length8() {
+        const length = this.readLength8();
+        return this.readData(length);
+    }
+
+    readData_Length16LE() {
+        const length = this.readLength16LE();
+        return this.readData(length);
+    }
+
+    readData_Length32LE() {
+        const length = this.readLength32LE();
+        return this.readData(length);
+    }
+
+    readData_Length64LE() {
+        const length = this.readLength64LE();
+        return this.readData(length);
+    }
+
+    readData_terminated() {
+        let offset = this.readerIndex;
+        let nextByte;
+
+        for (;;) {
+            nextByte = this.data[offset];
+
+            if (nextByte === undefined) {
+                throw new Error("HDSDecoder: Reached end of data stream while reading terminated data!");
+            } else  if (nextByte === DataFormatTags.TERMINATOR) {
+                break;
+            } else {
+                offset++;
+            }
+        }
+
+        const value = this.data.slice(this.readerIndex, offset);
+        this.readerIndex = offset + 1;
+        return this.cache(value);
+    }
+
+    readSecondsSince2001_01_01() {
+        // second since 2001-01-01 00:00:00
+        return this.readFloat64LE();
+    }
+
+    readUUID() { // big endian
+        this.ensureLength(16);
+        const value = uuid.unparse(this.data, this.readerIndex);
+        this.readerIndex += 16;
+        return this.cache(value);
+    }
+
+}
+
+class WrittenDataList { // wrapper class since javascript doesn't really have a way to override === operator
+
+    private writtenData: any[] = [];
+
+    push(data: any) {
+        this.writtenData.push(data);
+    }
+
+    indexOf(data: any) {
+        for (let i = 0; i < this.writtenData.length; i++) {
+            const data0 = this.writtenData[i];
+
+            if (data === data0) {
+                return i;
+            }
+
+            if (data instanceof ValueWrapper && data0 instanceof ValueWrapper) {
+                if (data.equals(data0)) {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+}
+
+export class DataStreamWriter {
+
+    private static readonly chunkSize = 128; // seems to be a good default
+
+    private data: Buffer;
+    private writerIndex: number;
+
+    private writtenData = new WrittenDataList();
+
+    constructor() {
+        this.data = Buffer.alloc(DataStreamWriter.chunkSize);
+        this.writerIndex = 0;
+    }
+
+    length() {
+        return this.writerIndex; // since writerIndex points to the next FREE index it also represents the length
+    }
+
+    getData() {
+        return this.data.slice(0, this.writerIndex);
+    }
+
+    private ensureLength(bytes: number) {
+        const neededBytes = (this.writerIndex + bytes) - this.data.length;
+        if (neededBytes > 0) {
+            const chunks = Math.ceil(neededBytes / DataStreamWriter.chunkSize);
+
+            // don't know if it's best for performance to immediately concatenate the buffers. That way it's
+            // the easiest way to handle writing though.
+            this.data = Buffer.concat([this.data, Buffer.alloc(chunks * DataStreamWriter.chunkSize)]);
+        }
+    }
+
+    private checkDeduplication(data: any): boolean {
+        const index = this.writtenData.indexOf(data);
+        if (index < 0) {
+            // data is not present yet
+            this.writtenData.push(data);
+            return false;
+        } else if (index <= DataFormatTags.DEDUPLICATION_STOP - DataFormatTags.DEDUPLICATION_START) {
+            // data was already written and the index is in the applicable range => shorten the payload
+            this.writeTag(DataFormatTags.DEDUPLICATION_START + index);
+            return true;
+        }
+
+        return false;
+    }
+
+    writeTag(tag: DataFormatTags) {
+        this.ensureLength(1);
+        this.data.writeUInt8(tag, this.writerIndex++);
+    }
+
+    writeTrue() {
+        this.writeTag(DataFormatTags.TRUE);
+    }
+
+    writeFalse() {
+        this.writeTag(DataFormatTags.FALSE);
+    }
+
+    writeNumber(number: number) {
+        if (number === -1) {
+            this.writeTag(DataFormatTags.INTEGER_MINUS_ONE);
+        } else if (number >= 0 && number <= 39) {
+            this.writeTag(DataFormatTags.INTEGER_RANGE_START_0 + number);
+        } else if (number >= -128 && number <= 127) {
+            this.writeInt8(new Int8(number));
+        } else if (number >= -32768 && number <= 32767) {
+            this.writeInt16LE(new Int16(number));
+        } else if (number >= -2147483648 && number <= -2147483648) {
+            this.writeInt32LE(new Int32(number));
+        } else if (number >= Number.MIN_SAFE_INTEGER && number <= Number.MAX_SAFE_INTEGER) { // use correct uin64 restriction when we convert to bigint
+            this.writeInt64LE(new Int64(number));
+        } else {
+            throw new Error("Tried writing unrepresentable number (" + number + ")");
+        }
+    }
+
+    writeInt8(int8: Int8) {
+        if (this.checkDeduplication(int8)) {
+            return;
+        }
+
+        this.ensureLength(2);
+        this.writeTag(DataFormatTags.INT8);
+        this.data.writeInt8(int8.value, this.writerIndex++);
+    }
+
+    writeInt16LE(int16: Int16) {
+        if (this.checkDeduplication(int16)) {
+            return;
+        }
+
+        this.ensureLength(3);
+        this.writeTag(DataFormatTags.INT16LE);
+        this.data.writeInt16LE(int16.value, this.writerIndex);
+        this.writerIndex += 2;
+    }
+
+    writeInt32LE(int32: Int32) {
+        if (this.checkDeduplication(int32)) {
+            return;
+        }
+
+        this.ensureLength(5);
+        this.writeTag(DataFormatTags.INT32LE);
+        this.data.writeInt32LE(int32.value, this.writerIndex);
+        this.writerIndex += 4;
+    }
+
+    writeInt64LE(int64: Int64) {
+        if (this.checkDeduplication(int64)) {
+            return;
+        }
+
+        this.ensureLength(9);
+        this.writeTag(DataFormatTags.INT64LE);
+        this.data.writeUInt32LE(int64.value, this.writerIndex);// TODO correctly implement int64; currently it's basically an int32
+        this.data.writeUInt32LE(0, this.writerIndex + 4);
+        this.writerIndex += 8;
+    }
+
+    writeFloat32LE(float32: Float32) {
+        if (this.checkDeduplication(float32)) {
+            return;
+        }
+
+        this.ensureLength(5);
+        this.writeTag(DataFormatTags.FLOAT32LE);
+        this.data.writeFloatLE(float32.value, this.writerIndex);
+        this.writerIndex += 4;
+    }
+
+    writeFloat64LE(float64: Float64) {
+        if (this.checkDeduplication(float64)) {
+            return;
+        }
+
+        this.ensureLength(9);
+        this.writeTag(DataFormatTags.FLOAT64LE);
+        this.data.writeDoubleLE(float64.value, this.writerIndex);
+        this.writerIndex += 8;
+    }
+
+    private writeLength8(length: number) {
+        this.ensureLength(1);
+        this.data.writeUInt8(length, this.writerIndex++);
+    }
+
+    private writeLength16LE(length: number) {
+        this.ensureLength(2);
+        this.data.writeUInt16LE(length, this.writerIndex);
+        this.writerIndex += 2;
+    }
+
+    private writeLength32LE(length: number) {
+        this.ensureLength(4);
+        this.data.writeUInt32LE(length, this.writerIndex);
+        this.writerIndex += 4;
+    }
+
+    private writeLength64LE(length: number) {
+        this.ensureLength(8);
+        encryption.writeUInt64LE(length, this.data, this.writerIndex);
+        this.writerIndex += 8;
+    }
+
+    writeUTF8(utf8: string) {
+        if (this.checkDeduplication(utf8)) {
+            return;
+        }
+
+        const length = Buffer.byteLength(utf8);
+        if (length <= 32) {
+            this.ensureLength(1 + length);
+            this.writeTag(DataFormatTags.UTF8_LENGTH_START + utf8.length);
+            this._writeUTF8(utf8);
+        } else if (length <= 255) {
+            this.writeUTF8_Length8(utf8);
+        } else if (length <= 65535) {
+            this.writeUTF8_Length16LE(utf8);
+        } else if (length <= 4294967295) {
+            this.writeUTF8_Length32LE(utf8);
+        } else if (length <= Number.MAX_SAFE_INTEGER) { // use correct uin64 restriction when we convert to bigint
+            this.writeUTF8_Length64LE(utf8);
+        } else {
+            this.writeUTF8_NULL_terminated(utf8);
+        }
+    }
+
+    private _writeUTF8(utf8: string) { // utility method
+        const byteLength = Buffer.byteLength(utf8);
+        this.ensureLength(byteLength);
+
+        this.data.write(utf8, this.writerIndex, "utf8");
+        this.writerIndex += byteLength;
+    }
+
+    private writeUTF8_Length8(utf8: string) {
+        const length = Buffer.byteLength(utf8);
+        this.ensureLength(2 + length);
+
+        this.writeTag(DataFormatTags.UTF8_LENGTH8);
+        this.writeLength8(length);
+        this._writeUTF8(utf8);
+    }
+
+    private writeUTF8_Length16LE(utf8: string) {
+        const length = Buffer.byteLength(utf8);
+        this.ensureLength(3 + length);
+
+        this.writeTag(DataFormatTags.UTF8_LENGTH16LE);
+        this.writeLength16LE(length);
+        this._writeUTF8(utf8);
+    }
+
+    private writeUTF8_Length32LE(utf8: string) {
+        const length = Buffer.byteLength(utf8);
+        this.ensureLength(5 + length);
+
+        this.writeTag(DataFormatTags.UTF8_LENGTH32LE);
+        this.writeLength32LE(length);
+        this._writeUTF8(utf8);
+    }
+
+    private writeUTF8_Length64LE(utf8: string) {
+        const length = Buffer.byteLength(utf8);
+        this.ensureLength(9 + length);
+
+        this.writeTag(DataFormatTags.UTF8_LENGTH64LE);
+        this.writeLength64LE(length);
+        this._writeUTF8(utf8);
+    }
+
+    private writeUTF8_NULL_terminated(utf8: string) {
+        this.ensureLength(1 + Buffer.byteLength(utf8) + 1);
+
+        this.writeTag(DataFormatTags.UTF8_NULL_TERMINATED);
+        this._writeUTF8(utf8);
+        this.data.writeUInt8(0, this.writerIndex++);
+    }
+
+    writeData(data: Buffer) {
+        if (this.checkDeduplication(data)) {
+            return;
+        }
+
+        if (data.length <= 32) {
+            this.writeTag(DataFormatTags.DATA_LENGTH_START + data.length);
+            this._writeData(data);
+        } else if (data.length <= 255) {
+            this.writeData_Length8(data);
+        } else if (data.length <= 65535) {
+            this.writeData_Length16LE(data);
+        } else if (data.length <= 4294967295) {
+            this.writeData_Length32LE(data);
+        } else if (data.length <= Number.MAX_SAFE_INTEGER) {
+            this.writeData_Length64LE(data);
+        } else {
+            this.writeData_terminated(data);
+        }
+    }
+
+    private _writeData(data: Buffer) { // utility method
+        this.ensureLength(data.length);
+        for (let i = 0; i < data.length; i++) {
+            this.data[this.writerIndex++] = data[i];
+        }
+    }
+
+    private writeData_Length8(data: Buffer) {
+        this.ensureLength(2 + data.length);
+
+        this.writeTag(DataFormatTags.DATA_LENGTH8);
+        this.writeLength8(data.length);
+        this._writeData(data);
+    }
+
+    private writeData_Length16LE(data: Buffer) {
+        this.ensureLength(3 + data.length);
+
+        this.writeTag(DataFormatTags.DATA_LENGTH16LE);
+        this.writeLength16LE(data.length);
+        this._writeData(data);
+    }
+
+    private writeData_Length32LE(data: Buffer) {
+        this.ensureLength(5 + data.length);
+
+        this.writeTag(DataFormatTags.DATA_LENGTH32LE);
+        this.writeLength32LE(data.length);
+        this._writeData(data);
+    }
+
+    private writeData_Length64LE(data: Buffer) {
+        this.ensureLength(9 + data.length);
+
+        this.writeTag(DataFormatTags.DATA_LENGTH64LE);
+        this.writeLength64LE(data.length);
+        this._writeData(data);
+    }
+
+    private writeData_terminated(data: Buffer) {
+        this.ensureLength(1 + data.length + 1);
+
+        this.writeTag(DataFormatTags.DATA_TERMINATED);
+        this._writeData(data);
+        this.writeTag(DataFormatTags.TERMINATOR);
+    }
+
+    writeSecondsSince2001_01_01(seconds: SecondsSince2001) {
+        if (this.checkDeduplication(seconds)) {
+            return;
+        }
+
+        this.ensureLength(9);
+        this.writeTag(DataFormatTags.DATE);
+        this.data.writeDoubleLE(seconds.value, this.writerIndex);
+        this.writerIndex += 8;
+    }
+
+    writeUUID(uuid_string: string) {
+        assert(uuid.isValid(uuid_string), "supplied uuid is invalid");
+        if (this.checkDeduplication(new UUID(uuid_string))) {
+            return;
+        }
+
+        this.ensureLength(17);
+        this.writeTag(DataFormatTags.UUID);
+        uuid.write(uuid_string, this.data, this.writerIndex);
+        this.writerIndex += 16;
+    }
+
+}

--- a/src/lib/datastream/DataStreamServer.ts
+++ b/src/lib/datastream/DataStreamServer.ts
@@ -1,0 +1,923 @@
+import createDebug from 'debug';
+import bufferShim from "buffer-shims";
+import assert from 'assert';
+
+import * as encryption from '../util/encryption';
+import * as hkdf from '../util/hkdf';
+import {DataStreamParser, DataStreamReader, DataStreamWriter, Int64} from './DataStreamParser';
+import crypto from 'crypto';
+import net, {Socket} from 'net';
+import {HAPSessionEvents, Session} from "../util/eventedhttp";
+import {EventEmitter as NodeEventEmitter} from "events";
+import {EventEmitter} from "../EventEmitter";
+import Timeout = NodeJS.Timeout;
+
+const debug = createDebug('DataStream:Server');
+
+export type PreparedDataStreamSession = {
+
+    session: Session, // reference to the hap session which created the request
+
+    accessoryToControllerEncryptionKey: Buffer,
+    controllerToAccessoryEncryptionKey: Buffer,
+    accessoryKeySalt: Buffer,
+
+    port?: number,
+
+    connectTimeout?: Timeout, // 10s timer
+
+}
+
+export type EventHandler = (message: Record<any, any>) => void;
+export type RequestHandler = (id: number, message: Record<any, any>) => void;
+export type ResponseHandler = (error: Error | undefined, status: number | undefined, message: Record<any, any>) => void;
+export type GlobalEventHandler = (connection: DataStreamConnection, message: Record<any, any>) => void;
+export type GlobalRequestHandler = (connection: DataStreamConnection, id: number, message: Record<any, any>) => void;
+
+export interface DataStreamProtocolHandler {
+
+    eventHandler?: Record<string, EventHandler>,
+    requestHandler?: Record<string, RequestHandler>,
+
+}
+
+export enum Protocols { // a collection of currently known protocols
+    CONTROL = "control",
+    TARGET_CONTROL = "targetControl",
+    DATA_SEND = "dataSend",
+}
+
+export enum Topics { // a collection of currently known topics grouped by their protocol
+    // control
+    HELLO = "hello",
+
+    // targetControl
+    WHOAMI = "whoami",
+
+    // dataSend
+    OPEN = "open",
+    DATA = "data",
+    ACK = "ack",
+    CLOSE = "close",
+}
+
+export enum DataSendCloseReason {
+    NORMAL = 0,
+    NOT_ALLOWED = 1,
+    BUSY = 2,
+    CANCELLED = 4,
+    UNSUPPORTED = 4,
+    UNEXPECTED_FAILURE = 5,
+    TIMEOUT = 6,
+}
+
+
+enum ServerState {
+    UNINITIALIZED, // server socket hasn't been created
+    BINDING, // server is created and is currently trying to bind
+    LISTENING, // server is created and currently listening for new connections
+    CLOSING,
+}
+
+enum ConnectionState {
+    UNIDENTIFIED,
+    EXPECTING_HELLO,
+    READY,
+    CLOSING,
+    CLOSED,
+}
+
+type HDSFrame = {
+
+    header: Buffer,
+    cipheredPayload: Buffer,
+    plaintextPayload: Buffer,
+    authTag: Buffer,
+
+}
+
+enum MessageType {
+    EVENT = 1,
+    REQUEST = 2,
+    RESPONSE = 3,
+}
+
+type DataStreamMessage = {
+    type: MessageType,
+
+    protocol: string,
+    topic: string,
+    id?: number, // for requests and responses
+    status?: number, // for responses
+
+    message: Record<any, any>,
+}
+
+export enum DataStreamServerEvents {
+    CONNECTION_OPENED = "connection-opened",
+    CONNECTION_CLOSED = "connection-closed",
+}
+
+export type DataStreamServerEventMap = {
+    [DataStreamServerEvents.CONNECTION_OPENED]: (connection: DataStreamConnection) => void;
+    [DataStreamServerEvents.CONNECTION_CLOSED]: (connection: DataStreamConnection) => void;
+}
+
+/**
+ * DataStreamServer which listens for incoming tcp connections and handles identification of new connections
+ *
+ * @event 'connection-opened': (connection: DataStreamConnection) => void
+ *        This event is emitted when a new client socket is received. At this point we have no idea to what
+ *        hap session this connection will be matched.
+ *
+ * @event 'connection-closed': (connection: DataStreamConnection) => void
+ *        This event is emitted when the socket of a connection gets closed.
+ */
+export class DataStreamServer extends EventEmitter<DataStreamServerEventMap> {
+
+    static readonly version = "1.0";
+
+    private state: ServerState = ServerState.UNINITIALIZED;
+
+    private static accessoryToControllerInfo = bufferShim.from("HDS-Read-Encryption-Key");
+    private static controllerToAccessoryInfo = bufferShim.from("HDS-Write-Encryption-Key");
+
+    private tcpServer?: net.Server;
+    private tcpPort?: number;
+
+    preparedSessions: PreparedDataStreamSession[];
+    private connections: DataStreamConnection[];
+
+    private readonly internalEventEmitter: NodeEventEmitter = new NodeEventEmitter(); // used for message event and message request handlers
+
+    constructor() {
+        super();
+        this.preparedSessions = [];
+        this.connections = [];
+    }
+
+    /**
+     * Registers a new event handler to handle incoming event messages.
+     * The handler is only called for a connection if for the give protocol no ProtocolHandler
+     * was registered on the connection level.
+     *
+     * @param protocol {string | Protocols} - name of the protocol to register the handler for
+     * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
+     * @param handler {GlobalEventHandler} - function to be called for every occurring event
+     */
+    onEventMessage(protocol: string | Protocols, event: string | Topics, handler: GlobalEventHandler): this {
+        this.internalEventEmitter.on(protocol + "-e-" + event, handler);
+        return this;
+    }
+
+    /**
+     * Removes an registered event handler.
+     *
+     * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
+     * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
+     * @param handler {GlobalEventHandler} - registered event handler
+     */
+    removeEventHandler(protocol: string | Protocols, event: string | Topics, handler: GlobalEventHandler): this {
+        this.internalEventEmitter.removeListener(protocol + "-e-" + event, handler);
+        return this;
+    }
+
+    /**
+     * Registers a new request handler to handle incoming request messages.
+     * The handler is only called for a connection if for the give protocol no ProtocolHandler
+     * was registered on the connection level.
+     *
+     * @param protocol {string | Protocols} - name of the protocol to register the handler for
+     * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
+     * @param handler {GlobalRequestHandler} - function to be called for every occurring request
+     */
+    onRequestMessage(protocol: string | Protocols, request: string | Topics, handler: GlobalRequestHandler): this {
+        this.internalEventEmitter.on(protocol + "-r-" + request, handler);
+        return this;
+    }
+
+    /**
+     * Removes an registered request handler.
+     *
+     * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
+     * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
+     * @param handler {GlobalRequestHandler} - registered request handler
+     */
+    removeRequestHandler(protocol: string | Protocols, request: string | Topics, handler: GlobalRequestHandler): this {
+        this.internalEventEmitter.removeListener(protocol + "-r-" + request, handler);
+        return this;
+    }
+
+    prepareSession(session: Session, controllerKeySalt: Buffer, callback: (preparedSession: PreparedDataStreamSession) => void) {
+        debug("Preparing for incoming HDS connection from session %s", session.sessionID);
+        const accessoryKeySalt = crypto.randomBytes(32);
+        const salt = Buffer.concat([controllerKeySalt, accessoryKeySalt]);
+
+        const accessoryToControllerEncryptionKey = hkdf.HKDF("sha512", salt, session.encryption!.sharedSec, DataStreamServer.accessoryToControllerInfo, 32);
+        const controllerToAccessoryEncryptionKey = hkdf.HKDF("sha512", salt, session.encryption!.sharedSec, DataStreamServer.controllerToAccessoryInfo, 32);
+
+        const preparedSession: PreparedDataStreamSession = {
+            session: session,
+            accessoryToControllerEncryptionKey: accessoryToControllerEncryptionKey,
+            controllerToAccessoryEncryptionKey: controllerToAccessoryEncryptionKey,
+            accessoryKeySalt: accessoryKeySalt,
+            connectTimeout: setTimeout(() => this.timeoutPreparedSession(preparedSession), 10000),
+        };
+        this.preparedSessions.push(preparedSession);
+
+        this.checkTCPServerEstablished(preparedSession, () => callback(preparedSession));
+    }
+
+    private timeoutPreparedSession(preparedSession: PreparedDataStreamSession) {
+        debug("Prepared HDS session timed out out since no connection was opened for 10 seconds (%s)", preparedSession.session.sessionID);
+        const index = this.preparedSessions.indexOf(preparedSession);
+        if (index >= 0) {
+            this.preparedSessions.splice(index, 1);
+        }
+
+        this.checkCloseable();
+    }
+
+    private checkTCPServerEstablished(preparedSession: PreparedDataStreamSession, callback: () => void) {
+        switch (this.state) {
+            case ServerState.UNINITIALIZED:
+                debug("Starting up TCP server.");
+                this.tcpServer = net.createServer();
+
+                this.tcpServer.once('listening', this.listening.bind(this, preparedSession, callback));
+                this.tcpServer.on('connection', this.onConnection.bind(this));
+                this.tcpServer.on('close', this.closed.bind(this));
+
+                this.tcpServer.listen();
+                this.state = ServerState.BINDING;
+                break;
+            case ServerState.BINDING:
+                debug("TCP server already running. Waiting for it to bind.");
+                this.tcpServer!.once('listening', this.listening.bind(this, preparedSession, callback));
+                break;
+            case ServerState.LISTENING:
+                debug("Instructing client to connect to already running TCP server");
+                preparedSession.port = this.tcpPort;
+                callback();
+                break;
+            case ServerState.CLOSING:
+                debug("TCP socket is currently closing. Trying again when server is fully closed and opening a new one then.");
+                this.tcpServer!.once('close', () => setTimeout(() => this.checkTCPServerEstablished(preparedSession, callback), 10));
+                break;
+        }
+    }
+
+    private listening(preparedSession: PreparedDataStreamSession, callback: () => void) {
+        this.state = ServerState.LISTENING;
+
+        const address = this.tcpServer!.address();
+        if (address && typeof address !== "string") { // address is only typeof string when listening to a pipe or unix socket
+            this.tcpPort = address.port;
+            preparedSession.port = address.port;
+
+            debug("TCP server is now listening for new data stream connections on port %s", address.port);
+            callback();
+        }
+    }
+
+    private onConnection(socket: Socket) {
+        debug("[%s] New DataStream connection was established", socket.remoteAddress);
+        const connection = new DataStreamConnection(socket);
+
+        connection.on(DataStreamConnectionEvents.IDENTIFICATION, this.handleSessionIdentification.bind(this, connection));
+        connection.on(DataStreamConnectionEvents.HANDLE_MESSAGE_GLOBALLY, this.handleMessageGlobally.bind(this, connection));
+        connection.on(DataStreamConnectionEvents.CLOSED, this.connectionClosed.bind(this, connection));
+
+        this.connections.push(connection);
+
+        this.emit(DataStreamServerEvents.CONNECTION_OPENED, connection);
+    }
+
+    private handleSessionIdentification(connection: DataStreamConnection, firstFrame: HDSFrame, callback: IdentificationCallback) {
+        let identifiedSession: PreparedDataStreamSession | undefined = undefined;
+        for (let i = 0; i < this.preparedSessions.length; i++) {
+            const preparedSession = this.preparedSessions[i];
+
+            // if we successfully decrypt the first frame with this key we know to which session this connection belongs
+            if (connection.decryptHDSFrame(firstFrame, preparedSession.controllerToAccessoryEncryptionKey)) {
+                identifiedSession = preparedSession;
+                break;
+            }
+        }
+
+        callback(identifiedSession);
+
+        if (identifiedSession) {
+            debug("[%s] Connection was successfully identified (linked with sessionId: %s)", connection._remoteAddress, identifiedSession.session.sessionID);
+            const index = this.preparedSessions.indexOf(identifiedSession);
+            if (index >= 0) {
+                this.preparedSessions.splice(index, 1);
+            }
+
+            clearTimeout(identifiedSession.connectTimeout!);
+            identifiedSession.connectTimeout = undefined;
+
+            // we have currently no experience with data stream connections, maybe it would be good to index active connections
+            // by their hap sessionId in order to clear out old but still open connections when the controller opens a new one
+            // on the other han the keepAlive should handle that also :thinking:
+        } else { // we looped through all session and didn't find anything
+            debug("[%s] Could not identify connection. Terminating.", connection._remoteAddress);
+            connection.close(); // disconnecting since first message was not a valid hello
+        }
+    }
+
+    private handleMessageGlobally(connection: DataStreamConnection, message: DataStreamMessage) {
+        assert.notStrictEqual(message.type, MessageType.RESPONSE); // responses can't physically get here
+
+        let separator = "";
+        let args: any[] = [];
+        if (message.type === MessageType.EVENT) {
+            separator = "-e-";
+        } else if (message.type === MessageType.REQUEST) {
+            separator = "-r-";
+            args.push(message.id!);
+        }
+        args.push(message.message);
+
+        let hadListeners;
+        try {
+            hadListeners = this.internalEventEmitter.emit(message.protocol + separator + message.topic, connection, ...args);
+        } catch (error) {
+            hadListeners = true;
+            debug("[%s] Error occurred while dispatching handler for HDS message: %o", connection._remoteAddress, message);
+            debug(error.stack);
+        }
+
+        if (!hadListeners) {
+            debug("[%s] WARNING no handler was found for message: %o", connection._remoteAddress, message);
+        }
+    }
+
+    private connectionClosed(connection: DataStreamConnection) {
+        debug("[%s] DataStream connection closed", connection._remoteAddress);
+
+        this.connections.splice(this.connections.indexOf(connection), 1);
+        this.emit(DataStreamServerEvents.CONNECTION_CLOSED, connection);
+
+        this.checkCloseable();
+    }
+
+    private checkCloseable() {
+        if (this.connections.length === 0 && this.preparedSessions.length === 0) {
+            debug("Last connection disconnected. Closing the server now.");
+
+            this.state = ServerState.CLOSING;
+            // noinspection JSIgnoredPromiseFromCall
+            this.tcpServer!.close();
+        }
+    }
+
+    private closed() {
+        this.tcpServer = undefined;
+        this.tcpPort = undefined;
+
+        this.state = ServerState.UNINITIALIZED;
+    }
+
+}
+
+export enum DataStreamConnectionEvents {
+    IDENTIFICATION = "identification",
+    HANDLE_MESSAGE_GLOBALLY = "handle-message-globally",
+    CLOSED = "closed",
+}
+
+export type IdentificationCallback = (identifiedSession?: PreparedDataStreamSession) => void;
+
+export type DataStreamConnectionEventMap = {
+    [DataStreamConnectionEvents.IDENTIFICATION]: (frame: HDSFrame, callback: IdentificationCallback) => void;
+    [DataStreamConnectionEvents.HANDLE_MESSAGE_GLOBALLY]: (message: DataStreamMessage) => void;
+    [DataStreamConnectionEvents.CLOSED]: () => void;
+}
+
+/**
+ * DataStream connection which holds any necessary state information, encryption an decryption keys, manages
+ * protocol handlers and also handles sending and receiving of data stream frames.
+ *
+ * @event 'identification': (frame: HDSFrame, callback: IdentificationCallback) => void
+ *        This event is emitted when the first HDSFrame is received from a new connection.
+ *        The connection expects the handler to identify the connection by trying to match the decryption keys.
+ *        If identification was successful the PreparedDataStreamSession should be supplied to the callback,
+ *        otherwise undefined should be supplied.
+ *
+ * @event 'handle-message-globally': (message: DataStreamMessage) => void
+ *        This event is emitted when no handler could be found for the given protocol of a event or request message.
+ *
+ * @event 'closed': () => void
+ *        This event is emitted when the socket of the connection was closed.
+ */
+export class DataStreamConnection extends EventEmitter<DataStreamConnectionEventMap> {
+
+    private static readonly MAX_PAYLOAD_LENGTH = 0x11111111111111111111;
+
+    private socket: Socket;
+    private session?: Session; // reference to the hap session. is present when state > UNIDENTIFIED
+    readonly _remoteAddress: string;
+    /*
+        Since our DataStream server does only listen on one port and this port is supplied to every client
+        which wants to connect, we do not really know which client is who when we receive a tcp connection.
+        Thus, we find the correct PreparedDataStreamSession object by testing the encryption keys of all available
+        prepared sessions. Then we can reference this connection with the correct session and mark it as identified.
+     */
+    private state: ConnectionState = ConnectionState.UNIDENTIFIED;
+
+    private accessoryToControllerEncryptionKey?: Buffer;
+    private controllerToAccessoryEncryptionKey?: Buffer;
+
+    private accessoryToControllerNonce: number;
+    private readonly accessoryToControllerNonceBuffer: Buffer;
+    private controllerToAccessoryNonce: number;
+    private readonly controllerToAccessoryNonceBuffer: Buffer;
+
+    private frameBuffer?: Buffer; // used to store incomplete HDS frames
+
+    private protocolHandlers: Record<string, DataStreamProtocolHandler> = {}; // used to store protocolHandlers identified by their protocol name
+
+    private responseHandlers: Record<number, ResponseHandler> = {}; // used to store responseHandlers indexed by their respective requestId
+    private responseTimers: Record<number, Timeout> = {}; // used to store response timeouts indexed by their respective requestId
+
+    private helloTimer?: Timeout;
+
+    constructor(socket: Socket) {
+        super();
+        this.socket = socket;
+        this._remoteAddress = socket.remoteAddress!;
+
+        this.socket.setNoDelay(true); // disable Nagle algorithm
+        this.socket.setKeepAlive(true);
+
+        this.accessoryToControllerNonce = 0;
+        this.accessoryToControllerNonceBuffer = Buffer.alloc(8);
+        this.controllerToAccessoryNonce = 0;
+        this.controllerToAccessoryNonceBuffer = Buffer.alloc(8);
+
+        this.addProtocolHandler(Protocols.CONTROL, {
+           requestHandler: {
+               [Topics.HELLO]: this.handleHello.bind(this)
+           }
+        });
+
+        this.helloTimer = setTimeout(() => {
+            debug("[%s] Hello message did not arrive in time. Killing the connection", this._remoteAddress);
+            this.close();
+        }, 10000);
+
+        this.socket.on('data', this.onSocketData.bind(this));
+        this.socket.on('error', this.onSocketError.bind(this));
+        this.socket.on('close', this.onSocketClose.bind(this)); // we MUST register for this event, otherwise the error will bubble up to the top and crash the node process entirely.
+    }
+
+    private handleHello(id: number, _message: Record<any, any>) {
+        // that hello is indeed the _first_ message received is verified in onSocketData(...)
+        debug("[%s] Received hello message from client", this._remoteAddress);
+
+        clearTimeout(this.helloTimer!);
+        this.helloTimer = undefined;
+
+        this.state = ConnectionState.READY;
+
+        this.sendResponse(Protocols.CONTROL, Topics.HELLO, id);
+    }
+
+    /**
+     * Registers a new protocol handler to handle incoming messages.
+     * The same protocol cannot be registered multiple times.
+     *
+     * @param protocol {string | Protocols} - name of the protocol to register the handler for
+     * @param protocolHandler {DataStreamProtocolHandler} - object to be registered as protocol handler
+     */
+    addProtocolHandler(protocol: string | Protocols, protocolHandler: DataStreamProtocolHandler): boolean {
+        if (this.protocolHandlers[protocol] !== undefined) {
+            return false;
+        }
+
+        this.protocolHandlers[protocol] = protocolHandler;
+        return true;
+    }
+
+    /**
+     * Removes a protocol handler if it is registered.
+     *
+     * @param protocol {string | Protocols} - name of the protocol to unregister the handler for
+     * @param protocolHandler {DataStreamProtocolHandler} - object which will be unregistered
+     */
+    removeProtocolHandler(protocol: string | Protocols, protocolHandler: DataStreamProtocolHandler) {
+        const current = this.protocolHandlers[protocol];
+
+        if (current === protocolHandler) {
+            delete this.protocolHandlers[protocol];
+        }
+    }
+
+    /**
+     * Sends a new event message to the connected client.
+     *
+     * @param protocol {string | Protocols} - name of the protocol
+     * @param event {string | Topics} - name of the event (also referred to as topic. See {Topics} for some known ones)
+     * @param message {Record<any, any>} - message dictionary which gets sent along the event
+     */
+    sendEvent(protocol: string | Protocols, event: string | Topics, message: Record<any, any> = {}) {
+        const header: Record<any, any> = {};
+        header["protocol"] = protocol;
+        header["event"] = event;
+
+        this.sendHDSFrame(header, message);
+    }
+
+    /**
+     * Sends a new request message to the connected client.
+     *
+     * @param protocol {string | Protocols} - name of the protocol
+     * @param request {string | Topics} - name of the request (also referred to as topic. See {Topics} for some known ones)
+     * @param message {Record<any, any>} - message dictionary which gets sent along the request
+     * @param callback {ResponseHandler} - handler which gets supplied with an error object if the response didn't
+     *                                     arrive in time or the status and the message dictionary from the response
+     */
+    sendRequest(protocol: string | Protocols, request: string | Topics, message: Record<any, any> = {}, callback: ResponseHandler) {
+        let requestId: number;
+        do { // generate unused requestId
+            // currently writing int64 to data stream is not really supported, so 32-bit int will be the max
+            requestId = Math.floor(Math.random() * 4294967295);
+        } while (this.responseHandlers[requestId] !== undefined);
+
+        this.responseHandlers[requestId] = callback;
+        this.responseTimers[requestId] = setTimeout(() => {
+            // we did not receive a response => close socket
+            this.close();
+
+            const handler = this.responseHandlers[requestId];
+
+            delete this.responseHandlers[requestId];
+            delete this.responseTimers[requestId];
+
+            // handler should be able to cleanup their stuff
+            handler(new Error("timeout"), undefined, {});
+        }, 10000); // 10s timer
+
+        const header: Record<any, any> = {};
+        header["protocol"] = protocol;
+        header["request"] = request;
+        header["id"] = new Int64(requestId);
+
+        this.sendHDSFrame(header, message);
+    }
+
+    /**
+     * Send a new response message to a received request message to the client.
+     *
+     * @param protocol {string | Protocols} - name of the protocol
+     * @param response {string | Topics} - name of the response (also referred to as topic. See {Topics} for some known ones)
+     * @param id {number} - id from the request, to associate the response to the request
+     * @param status {number} - status indication if the request was successful. A status of zero indicates success.
+     * @param message {Record<any, any>} - message dictionary which gets sent along the response
+     */
+    sendResponse(protocol: string | Protocols, response: string | Topics, id: number, status: number = 0, message: Record<any, any> = {}) {
+        const header: Record<any, any> = {};
+        header["protocol"] = protocol;
+        header["response"] = response;
+        header["id"] = new Int64(id);
+        header["status"] = new Int64(status);
+
+        this.sendHDSFrame(header, message);
+    }
+
+    private onSocketData(data: Buffer) {
+        if (this.state >= ConnectionState.CLOSING) {
+            return;
+        }
+
+        let frameIndex = 0;
+        const frames: HDSFrame[] = this.decodeHDSFrames(data);
+        if (frames.length === 0) { // not enough data
+            return;
+        }
+
+        if (this.state === ConnectionState.UNIDENTIFIED) {
+            // at the beginning we are only interested in trying to decrypt the first frame in order to test decryption keys
+            const firstFrame = frames[frameIndex++];
+            this.emit(DataStreamConnectionEvents.IDENTIFICATION, firstFrame, (identifiedSession?: PreparedDataStreamSession) => {
+               if (identifiedSession) {
+                   // horray, we found our session
+                   this.session = identifiedSession.session;
+                   this.accessoryToControllerEncryptionKey = identifiedSession.accessoryToControllerEncryptionKey;
+                   this.controllerToAccessoryEncryptionKey = identifiedSession.controllerToAccessoryEncryptionKey;
+                   this.state = ConnectionState.EXPECTING_HELLO;
+
+                   this.session.on(HAPSessionEvents.CLOSED, this.onHAPSessionClosed.bind(this)); // register close listener
+               }
+            });
+
+            if (this.state === ConnectionState.UNIDENTIFIED) {
+                // did not find a prepared session, server already closed this connection; nothing to do here
+                return;
+            }
+        }
+
+        for (; frameIndex < frames.length; frameIndex++) { // decrypt all remaining frames
+            if (!this.decryptHDSFrame(frames[frameIndex])) {
+                debug("[%s] HDS frame decryption or authentication failed. Connection will be terminated!", this._remoteAddress);
+                this.close();
+                return;
+            }
+        }
+
+        const messages: DataStreamMessage[] = this.decodePayloads(frames); // decode contents of payload
+
+        if (this.state === ConnectionState.EXPECTING_HELLO) {
+            const firstMessage = messages[0];
+
+            if (firstMessage.protocol !== Protocols.CONTROL || firstMessage.type !== MessageType.REQUEST || firstMessage.topic !== Topics.HELLO) {
+                // first message is not the expected hello request
+                debug("[%s] First message received was not the expected hello message. Instead got: %o", this._remoteAddress, firstMessage);
+                this.close();
+                return;
+            }
+        }
+
+        messages.forEach(message => {
+            if (message.type === MessageType.RESPONSE) {
+                // protocol and topic are currently not tested here; just assumed their are correct;
+                // probably they are as the requestId is unique per connection no matter what protocol is used
+                const responseHandler = this.responseHandlers[message.id!];
+                const responseTimer = this.responseTimers[message.id!];
+
+                if (responseTimer) {
+                    clearTimeout(responseTimer);
+                    delete this.responseTimers[message.id!];
+                }
+
+                if (!responseHandler) {
+                    // we got a response to a request we did not send; we ignore it for now, since nobody will be hurt
+                    debug("WARNING we received a response to a request we have not sent: %o", message);
+                    return;
+                }
+
+                try {
+                    responseHandler(undefined, message.status!, message.message);
+                } catch (error) {
+                    debug("[%s] Error occurred while dispatching response handler for HDS message: %o", this._remoteAddress, message);
+                    debug(error.stack);
+                }
+                delete this.responseHandlers[message.id!];
+            } else {
+                const handler = this.protocolHandlers[message.protocol];
+                if (handler === undefined) {
+                    // send message to the server to check if there are some global handlers for it
+                    this.emit(DataStreamConnectionEvents.HANDLE_MESSAGE_GLOBALLY, message);
+                    return;
+                }
+
+                if (message.type === MessageType.EVENT) {
+                    let eventHandler: EventHandler;
+                    if (!handler.eventHandler || !(eventHandler = handler.eventHandler[message.topic])) {
+                        debug("[%s] WARNING no event handler was found for message: %o", this._remoteAddress, message);
+                        return;
+                    }
+
+                    try {
+                        eventHandler(message.message);
+                    } catch (error) {
+                        debug("[%s] Error occurred while dispatching event handler for HDS message: %o", this._remoteAddress, message);
+                        debug(error.stack);
+                    }
+                } else if (message.type === MessageType.REQUEST) {
+                    let requestHandler: RequestHandler;
+                    if (!handler.requestHandler || !(requestHandler = handler.requestHandler[message.topic])) {
+                        debug("[%s] WARNING no request handler was found for message: %o", this._remoteAddress, message);
+                        return;
+                    }
+
+                    try {
+                        requestHandler(message.id!, message.message);
+                    } catch (error) {
+                        debug("[%s] Error occurred while dispatching request handler for HDS message: %o", this._remoteAddress, message);
+                        debug(error.stack);
+                    }
+                } else {
+                    debug("[%s] Encountered unknown message type with id %d", this._remoteAddress, message.type);
+                }
+            }
+        })
+    }
+
+    private decodeHDSFrames(data: Buffer) {
+        if (this.frameBuffer !== undefined) {
+            data = Buffer.concat([this.frameBuffer, data]);
+            this.frameBuffer = undefined;
+        }
+
+        const totalBufferLength = data.length;
+        const frames: HDSFrame[] = [];
+
+        for (let frameBegin = 0; frameBegin < totalBufferLength;) {
+            if (frameBegin + 4 > totalBufferLength) {
+                // we don't have enough data in the buffer for the next header
+                this.frameBuffer = data.slice(frameBegin);
+                break;
+            }
+
+            const payloadType = data.readUInt8(frameBegin); // type defining structure of payload; 8-bit; currently expected to be 1
+            const payloadLength = data.readUIntBE(frameBegin + 1, 3); // read 24-bit big-endian uint length field
+
+            if (payloadLength > DataStreamConnection.MAX_PAYLOAD_LENGTH) {
+                debug("[%s] Connection send payload with size bigger than the maximum allow for data stream", this._remoteAddress);
+                this.close();
+                return [];
+            }
+
+            const remainingBufferLength = totalBufferLength - frameBegin - 4; // subtract 4 for payloadType (1-byte) and payloadLength (3-byte)
+            // check if the data from this frame is already there (payload + 16-byte authTag)
+            if (payloadLength + 16 > remainingBufferLength) {
+                // Frame is fragmented, so we wait until we receive more
+                this.frameBuffer = data.slice(frameBegin);
+                break;
+            }
+
+            const payloadBegin = frameBegin + 4;
+            const authTagBegin = payloadBegin + payloadLength;
+
+            const header = data.slice(frameBegin, payloadBegin); // header is also authenticated using authTag
+            const cipheredPayload = data.slice(payloadBegin, authTagBegin);
+            const plaintextPayload = bufferShim.alloc(payloadLength);
+            const authTag = data.slice(authTagBegin, authTagBegin + 16);
+
+            frameBegin = authTagBegin + 16; // move to next frame
+
+            if (payloadType === 1) {
+                const hdsFrame: HDSFrame = {
+                    header: header,
+                    cipheredPayload: cipheredPayload,
+                    plaintextPayload: plaintextPayload,
+                    authTag: authTag,
+                };
+                frames.push(hdsFrame);
+            } else {
+                debug("[%s] Encountered unknown payload type %d for payload: %s", this._remoteAddress, plaintextPayload.toString('hex'));
+            }
+        }
+
+        return frames;
+    }
+
+    decryptHDSFrame(frame: HDSFrame, keyOverwrite?: Buffer): boolean {
+        encryption.writeUInt64LE(this.controllerToAccessoryNonce, this.controllerToAccessoryNonceBuffer, 0); // update nonce buffer
+
+        const key = keyOverwrite || this.controllerToAccessoryEncryptionKey!;
+        if (encryption.verifyAndDecrypt(key, this.controllerToAccessoryNonceBuffer,
+            frame.cipheredPayload, frame.authTag, frame.header, frame.plaintextPayload)) {
+            this.controllerToAccessoryNonce++; // we had a successful encryption, increment the nonce
+            return true;
+        } else {
+            // frame decryption or authentication failed. Could happen when our guess for a PreparedDataStreamSession is wrong
+            return false;
+        }
+    }
+
+    private decodePayloads(frames: HDSFrame[]) {
+        const messages: DataStreamMessage[] = [];
+
+        frames.forEach(frame => {
+            const payload = frame.plaintextPayload;
+
+            const headerLength = payload.readUInt8(0);
+            const messageLength = payload.length - headerLength - 1;
+
+            const headerBegin = 1;
+            const messageBegin = headerBegin + headerLength;
+
+            const headerPayload = new DataStreamReader(payload.slice(headerBegin, headerBegin + headerLength));
+            const messagePayload = new DataStreamReader(payload.slice(messageBegin, messageBegin + messageLength));
+
+            let headerDictionary: Record<any, any>;
+            let messageDictionary: Record<any, any>;
+            try {
+                headerDictionary = DataStreamParser.decode(headerPayload);
+                headerPayload.finished();
+            } catch (error) {
+                debug("[%s] Failed to decode header payload: %s", this._remoteAddress, error.message);
+                return;
+            }
+
+            try {
+                messageDictionary = DataStreamParser.decode(messagePayload);
+                messagePayload.finished();
+            } catch (error) {
+                debug("[%s] Failed to decode message payload: %s (header: %o)", this._remoteAddress, error.message, headerDictionary);
+                return;
+            }
+
+            let type: MessageType;
+            const protocol: string = headerDictionary["protocol"];
+            let topic: string;
+            let id: number | undefined = undefined;
+            let status: number | undefined = undefined;
+
+            if (headerDictionary["event"] !== undefined) {
+                type = MessageType.EVENT;
+                topic = headerDictionary["event"];
+            } else if (headerDictionary["request"] !== undefined) {
+                type = MessageType.REQUEST;
+                topic = headerDictionary["request"];
+                id = headerDictionary["id"];
+            } else if (headerDictionary["response"] !== undefined) {
+                type = MessageType.RESPONSE;
+                topic = headerDictionary["response"];
+                id = headerDictionary["id"];
+                status = headerDictionary["status"];
+            } else {
+                debug("[%s] Encountered unknown payload header format: %o (message: %o)", this._remoteAddress, headerDictionary, messageDictionary);
+                return;
+            }
+
+            const message = {
+                type: type,
+                protocol: protocol,
+                topic: topic,
+                id: id,
+                status: status,
+                message: messageDictionary,
+            };
+            messages.push(message);
+        });
+
+        return messages;
+    }
+
+    private sendHDSFrame(header: Record<any, any>, message: Record<any, any>) {
+        if (this.state >= ConnectionState.CLOSING) {
+            throw Error("Cannot send message on closing/closed socket!");
+        }
+
+        const headerWriter = new DataStreamWriter();
+        const messageWriter = new DataStreamWriter();
+
+        DataStreamParser.encode(header, headerWriter);
+        DataStreamParser.encode(message, messageWriter);
+
+
+        const payloadHeaderBuffer = Buffer.alloc(1);
+        payloadHeaderBuffer.writeUInt8(headerWriter.length(), 0);
+        const payloadBuffer = Buffer.concat([payloadHeaderBuffer, headerWriter.getData(), messageWriter.getData()]);
+        if (payloadBuffer.length > DataStreamConnection.MAX_PAYLOAD_LENGTH) {
+            throw new Error("Tried sending payload with length larger than the maximum allowed for data stream");
+        }
+
+        const frameTypeBuffer = Buffer.alloc(1);
+        frameTypeBuffer.writeUInt8(1, 0);
+        let frameLengthBuffer = Buffer.alloc(4);
+        frameLengthBuffer.writeUInt32BE(payloadBuffer.length, 0);
+        frameLengthBuffer = frameLengthBuffer.slice(1, 4); // a bit hacky but the only real way to write 24-bit int in node
+
+        const frameHeader = Buffer.concat([frameTypeBuffer, frameLengthBuffer]);
+        const authTag = Buffer.alloc(16);
+        const cipheredPayload = Buffer.alloc(payloadBuffer.length);
+
+        encryption.writeUInt64LE(this.accessoryToControllerNonce++, this.accessoryToControllerNonceBuffer);
+        encryption.encryptAndSeal(this.accessoryToControllerEncryptionKey!, this.accessoryToControllerNonceBuffer, payloadBuffer, frameHeader, cipheredPayload, authTag);
+
+        this.socket.write(Buffer.concat([frameHeader, cipheredPayload, authTag]));
+
+        /* Useful for debugging outgoing packages and detecting encoding errors
+        console.log("SENT DATA: " + payloadBuffer.toString("hex"));
+        const frame: HDSFrame = {
+            header: frameHeader,
+            plaintextPayload: payloadBuffer,
+            cipheredPayload: cipheredPayload,
+            authTag: authTag,
+        };
+        const sentMessage = this.decodePayloads([frame])[0];
+        console.log("Sent message: " + JSON.stringify(sentMessage, null, 4));
+        //*/
+    }
+
+    close() { // closing socket by sending FIN packet; incoming data will be ignored from that point on
+        if (this.state >= ConnectionState.CLOSING) {
+            return; // connection is already closing/closed
+        }
+
+        this.state = ConnectionState.CLOSING;
+        this.socket.end();
+    }
+
+    private onHAPSessionClosed() {
+        // If the hap session is closed it is probably also a good idea to close the data stream session
+        debug("[%s] HAP session disconnected. Also closing DataStream connection now.", this._remoteAddress);
+        this.close();
+    }
+
+    private onSocketError(error: Error) {
+        debug("[%s] Encountered socket error: %s", this._remoteAddress, error.message);
+        // onSocketClose will be called next
+    }
+
+    private onSocketClose() {
+        this.state = ConnectionState.CLOSED;
+        this.emit(DataStreamConnectionEvents.CLOSED);
+    }
+
+}

--- a/src/lib/datastream/index.ts
+++ b/src/lib/datastream/index.ts
@@ -1,0 +1,3 @@
+export * from './DataStreamManagement';
+export * from './DataStreamServer';
+export * from './DataStreamParser';

--- a/src/lib/util/encryption.ts
+++ b/src/lib/util/encryption.ts
@@ -234,7 +234,7 @@ function writeUInt64BE(number: number, buffer: Buffer, offset: number = 0) {
   buffer.writeUInt32BE(hl[1], offset + 4)
 }
 
-function writeUInt64LE (number: number, buffer: Buffer, offset: number = 0) {
+export function writeUInt64LE (number: number, buffer: Buffer, offset: number = 0) {
   var hl = uintHighLow(number)
   buffer.writeUInt32LE(hl[1], offset)
   buffer.writeUInt32LE(hl[0], offset + 4)

--- a/src/lib/util/uuid.ts
+++ b/src/lib/util/uuid.ts
@@ -36,3 +36,12 @@ export function unparse(buf: Buffer | string, offset: number = 0) {
          buf[i++].toString(16) + buf[i++].toString(16) +
          buf[i++].toString(16) + buf[i++].toString(16);
 }
+
+export function write(uuid: string, buf: Buffer, offset: number = 0) {
+  uuid = uuid.replace(/-/g, "");
+
+  for (let i = 0; i < uuid.length; i += 2) {
+    const octet = uuid.substring(i, i + 2);
+    buf.write(octet, offset++, "hex");
+  }
+}


### PR DESCRIPTION
This is part one of two PRs (Spoiler alter: part two will add support for Siri remotes. I'm finishing the last bits on that one).

This PR implements full support for HomeKit Data Streams.
The API is currently intended as follows:
* Step 1: You would create a new instance of the `DataStreamManagement` class and add the service returned by `getService()` to your accessory
* Step 2: finished

If an HomeKit Hub detects a combination of supported services it will create a connection.

You could then create some listeners for certain event messages with the respective protocol name (for example the `whoami` event message of the `targetControl` protocol. This is what the SiriRemote uses to identify DataStream sessions) or listen to more general events like `CONNECTION_OPENED` or `CONNECTION_CLOSED` to get a reference to an open data stream connection.

Once you got a reference to an `DataStreamConnection` you can add protocol handlers to that specific connection or send event, request or response messages.

As the HomeKit DataStream protocol supports different sized ints (int8, int16, int32, int64) I introduced some wrapper classes in `DataStreamParser.ts` (and also for some other data types) to mark how to encode the javascript number type. By default a number is encoded in the smallest possible type. It is ugly but I though it is the least ugly solution.
Also, as we have a minimum requirement of node v4 for the project currently, writing int64 isn't really supported. And also reading is a bit hacky but it seems to work (however we only really support 53 bit ints). The javascript bigint type is only support for node v10. The end goal would be to move to that data type (maybe?).
But feedback for any better solution to this problem is welcomed.