### PR TITLE
Fix error connecting after unpairing

### DIFF
--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -197,7 +197,7 @@ export class Session {
         sessions[index].authenticated = false;
         sessions.splice(index, 1);
       }
-      if (!sessions.length) delete this._server.sessions;
+      if (!sessions.length) delete this._server.sessions[this.username];
     }
   };
 
@@ -216,7 +216,6 @@ export class Session {
           session._connection._clientSocket.destroy();
         }
       });
-      if (!sessions.length) delete initiator._server.sessions;
     }
   };
 


### PR DESCRIPTION
Fixes an issue introduced in #735 where after unpairing any controller any new connections to the same server will crash the server with this error:

```
/Users/samuel/Documents/Projects/hap-nodejs/dist/lib/util/eventedhttp.js:143
            var sessions = _this._server.sessions[username];
                                                 ^

TypeError: Cannot read property 'pairingid' of undefined
    at Session.establishSession (/Users/samuel/Documents/Projects/hap-nodejs/dist/lib/util/eventedhttp.js:143:50)
    at HAPServer._this._handlePairVerifyStepTwo (/Users/samuel/Documents/Projects/hap-nodejs/dist/lib/HAPServer.js:619:21)
    at HAPServer._this._handlePairVerify (/Users/samuel/Documents/Projects/hap-nodejs/dist/lib/HAPServer.js:524:23)
    at IncomingMessage.<anonymous> (/Users/samuel/Documents/Projects/hap-nodejs/dist/lib/HAPServer.js:252:39)
    at IncomingMessage.emit (events.js:209:13)
    at endReadableNT (_stream_readable.js:1178:12)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
```