### PR TITLE
Adding support for Siri remotes

### DIFF
--- a/src/accessories/gstreamer-audioProducer.ts
+++ b/src/accessories/gstreamer-audioProducer.ts
@@ -1,0 +1,163 @@
+import assert from 'assert';
+import createDebug from 'debug';
+import {ChildProcessWithoutNullStreams, spawn} from 'child_process';
+import {AudioCodecConfiguration, ErrorHandler, FrameHandler, SiriAudioStreamProducer} from "../lib/HomeKitRemoteController";
+import {AudioCodecParamBitRateTypes, AudioCodecParamSampleRateTypes, AudioCodecTypes} from "../lib/StreamController";
+import {DataSendCloseReason} from "../index";
+
+const debug = createDebug("Remote:GStreamer");
+
+enum AudioType {
+    GENERIC = 2049,
+    VOICE = 2048
+}
+
+enum Bandwidth {
+    NARROW_BAND = 1101,
+    MEDIUM_BAND = 1102,
+    WIDE_BAND = 1103,
+    SUPER_WIDE_BAND = 1104,
+    FULL_BAND = 1105,
+    AUTO = -1000
+}
+
+enum BitrateType {
+    CONSTANT = 0,
+    VARIABLE = 1,
+}
+
+export type GStreamerOptions = {
+    alsaSrc: string,
+}
+
+/**
+ * SiriAudioStreamProducer utilizing gstreamer and alsa audio devices to create opus audio frames.
+ *
+ * This producer is mainly tested on a RaspberryPi, but should also work on other linux based devices using alsa.
+ *
+ * This producer requires some packages to be installed. It is adviced to install the following (for example via apt-get):
+ * gstreamer1.0-plugins-base, gstreamer1.0-x, gstreamer1.0-tools, libgstreamer1.0-dev, gstreamer1.0-doc,
+ * gstreamer1.0-plugins-good, gstreamer1.0-plugins- ugly, gstreamer1.0-plugins-bad, gstreamer1.0-alsa
+ *
+ */
+export class GStreamerAudioProducer implements SiriAudioStreamProducer {
+
+    private readonly options: GStreamerOptions = {
+        alsaSrc: "plughw:1"
+    };
+
+    private readonly frameHandler: FrameHandler;
+    private readonly errorHandler: ErrorHandler;
+
+    private process?: ChildProcessWithoutNullStreams;
+    private running: boolean = false;
+
+    constructor(frameHandler: FrameHandler, errorHandler: ErrorHandler, options?: Partial<GStreamerOptions>) {
+        this.frameHandler = frameHandler;
+        this.errorHandler = errorHandler;
+
+        for (const key in options) {
+            // @ts-ignore
+            GStreamerAudioProducer.options[key] = options[key];
+        }
+    }
+
+    startAudioProduction(selectedAudioConfiguration: AudioCodecConfiguration): void {
+        if (this.running) {
+            throw new Error("Gstreamer already running");
+        }
+
+        const codecParameters = selectedAudioConfiguration.parameters;
+        assert(selectedAudioConfiguration.codecType === AudioCodecTypes.OPUS);
+
+        let bitrateType = BitrateType.VARIABLE;
+        switch (codecParameters.bitrate) {
+            case AudioCodecParamBitRateTypes.CONSTANT:
+                bitrateType = BitrateType.CONSTANT;
+                break;
+            case AudioCodecParamBitRateTypes.VARIABLE:
+                bitrateType = BitrateType.VARIABLE;
+                break;
+        }
+
+        let bandwidth = Bandwidth.SUPER_WIDE_BAND;
+        switch (codecParameters.samplerate) {
+            case AudioCodecParamSampleRateTypes.KHZ_8:
+                bandwidth = Bandwidth.NARROW_BAND;
+                break;
+            case AudioCodecParamSampleRateTypes.KHZ_16:
+                bandwidth = Bandwidth.WIDE_BAND;
+                break;
+            case AudioCodecParamSampleRateTypes.KHZ_24:
+                bandwidth = Bandwidth.SUPER_WIDE_BAND;
+                break;
+        }
+
+        let packetTime = codecParameters.rtpTime;
+
+        debug("Launching gstreamer...");
+        this.running = true;
+
+        const args = "-q " +
+            "alsasrc device=" + this.options.alsaSrc + " ! " +
+            "capsfilter caps=audio/x-raw,format=S16LE,rate=24000 ! " +
+            // "level post-messages=true interval=" + packetTime + "000000 ! " + // used to capture rms
+            "opusenc " +
+                "bitrate-type=" + bitrateType + " " +
+                "bitrate=24000 " +
+                "audio-type=" + AudioType.VOICE + " " +
+                "bandwidth=" + bandwidth + " " +
+                "frame-size=" + packetTime + " ! " +
+            "fdsink fd=1";
+
+        this.process = spawn("gst-launch-1.0", args.split(" "), {env: process.env});
+        this.process.on("error", error => {
+            if (this.running) {
+                debug("Failed to spawn gstreamer process: " + error.message);
+                this.errorHandler(DataSendCloseReason.CANCELLED);
+            } else {
+                debug("Failed to kill gstreamer process: " + error.message);
+            }
+        });
+        this.process.stdout.on("data", (data: Buffer) => {
+            if (!this.running) { // received data after it was closed
+                return;
+            }
+
+            /*
+                This listener seems to get called with only one opus frame most of the time.
+                Though it happens regularly that another or many more frames get appended.
+                This causes some problems as opus frames don't contain their data length in the "header".
+                Opus relies on the container format to specify the length of the frame.
+                Although sometimes multiple opus frames are squashed together the decoder seems to be able
+                to handle that as it just creates a not very noticeable distortion.
+                If we would want to make this perfect we would need to write a nodejs c++ submodule or something
+                to interface directly with gstreamer api.
+             */
+
+            this.frameHandler({
+                data: data,
+                rms: 0.25 // only way currently to extract rms from gstreamer is by interfacing with the api directly (nodejs c++ submodule could be a solution)
+            });
+        });
+        this.process.stderr.on("data", data => {
+            debug("GStreamer process reports the following error: " + String(data));
+        });
+        this.process.on("exit", (code, signal) => {
+            if (signal !== "SIGTERM") { // if we receive SIGTERM, process exited gracefully (we stopped it)
+                debug("GStreamer process unexpectedly exited with code %d (signal: %s)", code, signal);
+                this.errorHandler(DataSendCloseReason.UNEXPECTED_FAILURE);
+            }
+        });
+    }
+
+    stopAudioProduction(): void {
+        if (this.running) {
+            this.process!.kill("SIGTERM");
+            this.running = false;
+        }
+
+        this.process = undefined;
+    }
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from './lib/StreamController';
 export * from './lib/HAPServer';
 export * from './lib/gen';
 export * from './lib/datastream';
+export * from './lib/HomeKitRemoteController';
 
 export * from './lib/util/chacha20poly1305';
 export * from './lib/util/clone';

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -80,6 +80,8 @@ export enum AccessoryEventTypes {
   LISTENING = "listening",
   SERVICE_CONFIGURATION_CHANGE = "service-configurationChange",
   SERVICE_CHARACTERISTIC_CHANGE = "service-characteristic-change",
+  PAIRED = "paired",
+  UNPAIRED = "unpaired",
 }
 
 type Events = {
@@ -87,6 +89,8 @@ type Events = {
   listening: (port: number) => void;
   "service-configurationChange": VoidCallback;
   "service-characteristic-change": (change: ServiceCharacteristicChange) => void;
+  [AccessoryEventTypes.PAIRED]: () => void;
+  [AccessoryEventTypes.UNPAIRED]: () => void;
 }
 
 /**
@@ -163,6 +167,7 @@ export class Accessory extends EventEmitter<Events> {
   aid: Nullable<number> = null; // assigned by us in assignIDs() or by a Bridge
   _isBridge: boolean = false; // true if we are a Bridge (creating a new instance of the Bridge subclass sets this to true)
   bridged: boolean = false; // true if we are hosted "behind" a Bridge Accessory
+  bridge?: Accessory; // if accessory is bridged, this property points to the bridge which bridges this accessory
   bridgedAccessories: Accessory[] = []; // If we are a Bridge, these are the Accessories we are bridging
   reachable: boolean = true;
   cameraSource: Nullable<Camera> = null;
@@ -331,6 +336,16 @@ export class Accessory extends EventEmitter<Events> {
     }
   }
 
+  /**
+   * Returns the bridging accessory if this accessory is bridged.
+   * Otherwise returns itself.
+   *
+   * @returns the primary accessory
+   */
+  getPrimaryAccessory = (): Accessory => {
+    return this.bridged? this.bridge!: this;
+  }
+
   updateReachability = (reachable: boolean) => {
     if (!this.bridged)
       throw new Error("Cannot update reachability on non-bridged accessory!");
@@ -365,6 +380,7 @@ export class Accessory extends EventEmitter<Events> {
     });
 
     accessory.bridged = true;
+    accessory.bridge = this;
 
     this.bridgedAccessories.push(accessory);
 
@@ -776,6 +792,8 @@ export class Accessory extends EventEmitter<Events> {
     this._advertiser && this._advertiser.updateAdvertisement();
 
     callback();
+
+    this.emit(AccessoryEventTypes.PAIRED);
   }
 
 // called when a controller adds an additional pairing
@@ -823,6 +841,7 @@ export class Accessory extends EventEmitter<Events> {
 
     if (!this._accessoryInfo.paired()) {
       this._advertiser && this._advertiser.updateAdvertisement();
+      this.emit(AccessoryEventTypes.UNPAIRED);
     }
 
     callback(0);

--- a/src/lib/HomeKitRemoteController.ts
+++ b/src/lib/HomeKitRemoteController.ts
@@ -1,19 +1,44 @@
 import * as tlv from './util/tlv';
 import bufferShim from "buffer-shims";
 import createDebug from 'debug';
+import assert from 'assert';
 
-import { Service } from "./Service";
+import {Service} from "./Service";
 import {
     Characteristic,
     CharacteristicEventTypes,
     CharacteristicGetCallback,
     CharacteristicSetCallback
 } from "./Characteristic";
-import { CharacteristicValue } from "../types";
-import { Status } from "./HAPServer";
-import { Accessory } from "./Accessory";
+import {CharacteristicValue} from "../types";
+import {Status} from "./HAPServer";
+import {Accessory, AccessoryEventTypes} from "./Accessory";
+import {
+    DataSendCloseReason,
+    DataStreamConnection,
+    DataStreamConnectionEvents,
+    DataStreamManagement,
+    DataStreamProtocolHandler,
+    DataStreamServerEvents,
+    EventHandler,
+    Float32,
+    Int64,
+    Protocols,
+    RequestHandler,
+    Topics
+} from "./datastream";
+import {
+    AudioCodecParamBitRateTypes,
+    AudioCodecParamSampleRateTypes,
+    AudioCodecParamTypes,
+    AudioCodecTypes,
+    AudioTypes
+} from "./StreamController";
+import {EventEmitter} from "./EventEmitter";
+import {HAPSessionEvents, Session} from "./util/eventedhttp";
+import Timeout = NodeJS.Timeout;
 
-const debug = createDebug('HomeKitRemoteController');
+const debug = createDebug('Remote:Controller');
 
 export enum TargetControlCommands {
     MAXIMUM_TARGETS = 0x01,
@@ -106,7 +131,7 @@ export type TargetConfiguration = {
     targetIdentifier: number,
     targetName?: string, // on Operation.UPDATE targetName is left out
     targetCategory?: TargetCategory, // on Operation.UPDATE targetCategory is left out
-    buttonConfiguration: ButtonConfiguration[]
+    buttonConfiguration: Record<number, ButtonConfiguration> // button configurations indexed by their ID
 }
 
 export type ButtonConfiguration = {
@@ -115,61 +140,292 @@ export type ButtonConfiguration = {
     buttonName?: string
 }
 
-export class HomeKitRemoteController {
 
+export enum SiriInputType {
+    PUSH_BUTTON_TRIGGERED_APPLE_TV = 0,
+}
+
+
+export enum SupportedAudioStreamConfigurationTypes {
+    AUDIO_CODEC_CONFIGURATION = 0x01,
+    COMFORT_NOISE_SUPPORT = 0x02,
+}
+
+export enum SelectedAudioInputStreamConfigurationTypes {
+    SELECTED_AUDIO_INPUT_STREAM_CONFIGURATION = 0x01,
+}
+
+export type SupportedAudioStreamConfiguration = {
+    audioCodecConfiguration: AudioCodecConfiguration,
+}
+
+export type SelectedAudioStreamConfiguration = {
+    audioCodecConfiguration: AudioCodecConfiguration,
+}
+
+export type AudioCodecConfiguration = {
+    codecType: AudioCodecTypes,
+    parameters: AudioCodecParameters,
+}
+
+export type AudioCodecParameters = {
+    channels: number, // number of audio channels, default is 1
+    bitrate: AudioCodecParamBitRateTypes,
+    samplerate: AudioCodecParamSampleRateTypes,
+    rtpTime?: RTPTime, // only present in SelectedAudioCodecParameters TLV
+}
+
+export type RTPTime = 20 | 30 | 40 | 60;
+
+
+export enum SiriAudioSessionState {
+    STARTING = 0, // we are currently waiting for a response for the start request
+    SENDING = 1, // we are sending data
+    CLOSING = 2, // we are currently waiting for the acknowledgment event
+    CLOSED = 3, // the close event was sent
+}
+
+export type DataSendMessageData = {
+    packets: AudioFramePacket[],
+    streamId: Int64,
+    endOfStream: boolean,
+}
+
+export type AudioFrame = {
+    data: Buffer,
+    rms: number, // root mean square
+}
+
+export type AudioFramePacket = {
+    data: Buffer,
+    metadata: {
+        rms: Float32, // root mean square
+        sequenceNumber: Int64,
+    },
+}
+
+
+export type FrameHandler = (frame: AudioFrame) => void;
+export type ErrorHandler = (error: DataSendCloseReason) => void;
+
+export interface SiriAudioStreamProducer {
+
+    startAudioProduction(selectedAudioConfiguration: AudioCodecConfiguration): void;
+
+    stopAudioProduction(): void;
+
+}
+
+export interface SiriAudioStreamProducerConstructor {
+
+    /**
+     * Creates a new instance of a SiriAudioStreamProducer
+     *
+     * @param frameHandler {FrameHandler} - called for every opus frame recorded
+     * @param errorHandler {ErrorHandler} - should be called with a appropriate reason when the producing process errored
+     * @param options - optional parameter for passing any configuration related options
+     */
+    new(frameHandler: FrameHandler, errorHandler: ErrorHandler, options?: any): SiriAudioStreamProducer;
+
+}
+
+export enum RemoteControllerEvents {
+    ACTIVE_CHANGE = "active-change",
+    ACTIVE_IDENTIFIER_CHANGE = "active-identifier-change",
+
+    TARGET_ADDED = "target-add",
+    TARGET_UPDATED = "target-update",
+    TARGET_REMOVED = "target-remove",
+    TARGETS_RESET = "targets-reset",
+}
+
+export enum TargetUpdates {
+    NAME,
+    CATEGORY,
+    UPDATED_BUTTONS,
+    REMOVED_BUTTONS,
+}
+
+export type RemoteControllerEventMap = {
+    [RemoteControllerEvents.ACTIVE_CHANGE]: (active: boolean) => void;
+    [RemoteControllerEvents.ACTIVE_IDENTIFIER_CHANGE]: (activeIdentifier: number) => void;
+
+    [RemoteControllerEvents.TARGET_ADDED]: (targetConfiguration: TargetConfiguration) => void;
+    [RemoteControllerEvents.TARGET_UPDATED]: (targetConfiguration: TargetConfiguration, updates: TargetUpdates[]) => void;
+    [RemoteControllerEvents.TARGET_REMOVED]: (targetIdentifier: number) => void;
+    [RemoteControllerEvents.TARGETS_RESET]: () => void;
+}
+
+/**
+ * Handles everything need to implement a fully working HomeKit remote controller.
+ *
+ * @event 'active-change': (active: boolean) => void
+ *        This event is emitted when the active state of the remote has changed.
+ *        active = true indicates that there is currently an apple tv listening of button presses and audio streams.
+ *
+ * @event 'active-identifier-change': (activeIdentifier: number) => void
+ *        This event is emitted when the currently selected target has changed.
+ *        Possible reasons for a changed active identifier: manual change via api call, first target configuration
+ *        gets added, active target gets removed, accessory gets unpaired, reset request was sent.
+ *        An activeIdentifier of 0 indicates that no target is selected.
+ *
+ *
+ * @event 'target-add': (targetConfiguration: TargetConfiguration) => void
+ *        This event is emitted when a new target configuration is received. As we currently do not persistently store
+ *        configured targets, this will be called at every startup for every Apple TV configured in the home.
+ *
+ * @event 'target-update': (targetConfiguration: TargetConfiguration, updates: TargetUpdates[]) => void
+ *        This event is emitted when a existing target was updated.
+ *        The 'updates' array indicates what exactly was changed for the target.
+ *
+ * @event 'target-remove': (targetIdentifier: number) => void
+ *        This event is emitted when a existing configuration for a target was removed.
+ *
+ * @event 'targets-reset': () => void
+ *        This event is emitted when a reset of the target configuration is requested.
+ *        With this event every configuration made should be reset. This event is also called
+ *        when the accessory gets unpaired.
+ */
+export class HomeKitRemoteController extends EventEmitter<RemoteControllerEventMap> implements DataStreamProtocolHandler {
+
+    audioSupported: boolean;
+    audioProducerConstructor?: SiriAudioStreamProducerConstructor;
+    audioProducerOptions?: any;
+
+    accessoryConfigured: boolean = false;
     targetControlManagementService?: Service;
     targetControlService?: Service;
 
-    buttons: Record<number, number>;
-    supportedConfiguration: string;
-    // it is advice to persistently store this configuration below, but HomeKit seems to just reconfigure itself
-    // after an reboot of the accessory. If someone has the time to implement persistent storage
-    // 'activeIdentifier' and 'active' should probably be included as well
-    targetConfigurations: Record<number, TargetConfiguration>;
-    targetConfigurationsString: string;
+    siriService?: Service;
+    audioStreamManagementService?: Service;
+    dataStreamManagement?: DataStreamManagement;
 
-    lastButtonEvent: string;
+    private buttons: Record<number, number> = {}; // internal mapping of buttonId to buttonType for supported buttons
+    private readonly supportedConfiguration: string;
+    /*
+        It is advice to persistently store this configuration below, but HomeKit seems to just reconfigure itself
+        after an reboot of the accessory.
+        If someone has the time to implement persistent storage 'activeIdentifier' and 'active'
+        should probably be included as well. Also a check at startup if we are still paired could be useful :thinking:
+     */
+    targetConfigurations: Record<number, TargetConfiguration> = {};
+    private  targetConfigurationsString: string = "";
 
-    activeIdentifier: number;
-    active: boolean;
+    private lastButtonEvent: string = "";
 
-    constructor() {
-        this.buttons = {};
+    activeIdentifier: number = 0; // id of 0 means no device selected
+    private activeSession?: Session; // session which marked this remote as active and listens for events and siri
+    private activeSessionDisconnectionListener?: () => void;
+
+    supportedAudioConfiguration: string;
+    selectedAudioConfiguration: AudioCodecConfiguration;
+    selectedAudioConfigurationString: string;
+
+    dataStreamConnections: Record<number, DataStreamConnection> = {}; // maps targetIdentifiers to active data stream connections
+    activeAudioSession?: SiriAudioSession;
+    nextAudioSession?: SiriAudioSession;
+
+    eventHandler?: Record<string, EventHandler>;
+    requestHandler?: Record<string, RequestHandler>;
+
+    /**
+     * Creates a new HomeKitRemoteController.
+     * If siri voice input is supported the constructor to an SiriAudioStreamProducer needs to be supplied.
+     * Otherwise a remote without voice support will be created.
+     *
+     * For every audio session a new SiriAudioStreamProducer will be constructed.
+     *
+     * @param audioProducerConstructor {SiriAudioStreamProducerConstructor} - constructor for a SiriAudioStreamProducer
+     * @param producerOptions - if supplied this argument will be supplied as third argument of the SiriAudioStreamProducer
+     *                          constructor. This should be used to supply configurations to the stream producer.
+     */
+    constructor(audioProducerConstructor?: SiriAudioStreamProducerConstructor, producerOptions?: any) {
+        super();
+        this.audioSupported = audioProducerConstructor !== undefined;
+        this.audioProducerConstructor = audioProducerConstructor;
+        this.audioProducerOptions = producerOptions;
+
         const configuration: SupportedConfiguration = this.constructSupportedConfiguration();
-        this.supportedConfiguration = this._targetControlSupportedConfiguration(configuration);
-        this.targetConfigurations = {};
-        this.targetConfigurationsString = "";
+        this.supportedConfiguration = this.buildTargetControlSupportedConfigurationTLV(configuration);
 
-        this.lastButtonEvent = "";
+        const audioConfiguration: SupportedAudioStreamConfiguration = this.constructSupportedAudioConfiguration();
+        this.supportedAudioConfiguration = this.buildSupportedAudioConfigurationTLV(audioConfiguration);
 
-        this.activeIdentifier = 0; // id of 0 means no device selected
-        this.active = false;
+        this.selectedAudioConfiguration = { // set the required defaults
+            codecType: AudioCodecTypes.OPUS,
+            parameters: {
+                channels: 1,
+                bitrate: AudioCodecParamBitRateTypes.VARIABLE,
+                samplerate: AudioCodecParamSampleRateTypes.KHZ_16,
+                rtpTime: 20,
+            }
+        };
+        this.selectedAudioConfigurationString = this.buildSelectedAudioConfigurationTLV({
+            audioCodecConfiguration: this.selectedAudioConfiguration,
+        });
 
         this._createServices();
+
+        if (this.audioSupported) { // subscribe to necessary events if siri is enabled
+            this.dataStreamManagement!
+                .onEventMessage(Protocols.TARGET_CONTROL, Topics.WHOAMI, this.handleTargetControlWhoAmI.bind(this))
+                .onServerEvent(DataStreamServerEvents.CONNECTION_CLOSED, this.handleDataStreamConnectionClosed.bind(this));
+
+            this.eventHandler = {
+                [Topics.ACK]: this.handleDataSendAckEvent.bind(this),
+                [Topics.CLOSE]: this.handleDataSendCloseEvent.bind(this),
+            };
+        }
     }
 
-    pushButton = (button: ButtonType) => {
-        const timestamp = new Date().getTime();
-        this._buttonEvent(this.buttons[button], ButtonState.DOWN, timestamp, this.activeIdentifier);
-        debug("Pressed button %d", button);
-    };
-
-    releaseButton = (button: ButtonType) => {
-        const timestamp = new Date().getTime();
-        this._buttonEvent(this.buttons[button], ButtonState.UP, timestamp, this.activeIdentifier);
-        debug("Released button %d", button);
-    };
-
+    /**
+     * Set a new target as active target. A value of 0 indicates that no target is selected currently.
+     *
+     * @param activeIdentifier {number} - target identifier
+     */
     setActiveIdentifier = (activeIdentifier: number) => {
-        debug("%d is now active", activeIdentifier);
+        if (activeIdentifier === this.activeIdentifier) {
+            return;
+        }
+
+        if (activeIdentifier !== 0 && !this.targetConfigurations[activeIdentifier]) {
+            throw Error("Tried setting unconfigured targetIdentifier to active");
+        }
+
+        debug("%d is now the active target", activeIdentifier);
         this.activeIdentifier = activeIdentifier;
         this.targetControlService!.getCharacteristic(Characteristic.ActiveIdentifier)!.updateValue(activeIdentifier);
+
+        if (this.activeAudioSession) {
+            this.handleSiriAudioStop();
+        }
+
+        setTimeout(() => this.emit(RemoteControllerEvents.ACTIVE_IDENTIFIER_CHANGE, activeIdentifier), 0);
+        this.setInactive();
     };
 
+    /**
+     * @returns if the current target is active, meaning the active device is listening for button events or audio sessions
+     */
+    isActive = () => {
+        return !!this.activeSession;
+    };
+
+    /**
+     * Checks if the supplied targetIdentifier is configured.
+     *
+     * @param targetIdentifier {number}
+     */
     isConfigured = (targetIdentifier: number) => {
         return this.targetConfigurations[targetIdentifier] !== undefined;
     };
 
+    /**
+     * Returns the targetIdentifier for a give device name
+     *
+     * @param name {string} - the name of the device
+     * @returns the targetIdentifier of the device or undefined if not existent
+     */
     getTargetIdentifierByName = (name: string) => {
         for (const activeIdentifier in this.targetConfigurations) {
             const configuration = this.targetConfigurations[activeIdentifier];
@@ -180,29 +436,89 @@ export class HomeKitRemoteController {
         return undefined;
     };
 
+    /**
+     * Sends a button event to press the supplied button.
+     *
+     * @param button {ButtonType} - button to be pressed
+     */
+    pushButton = (button: ButtonType) => {
+        debug("Pressing button %s", ButtonType[button]);
+        this.sendButtonEvent(button, ButtonState.DOWN);
+    };
+
+    /**
+     * Sends a button event that the supplied button was released.
+     *
+     * @param button {ButtonType} - button which was released
+     */
+    releaseButton = (button: ButtonType) => {
+        debug("Released button %s", ButtonType[button]);
+        this.sendButtonEvent(button, ButtonState.UP);
+    };
+
+    /**
+     * Presses a supplied button for a given time.
+     *
+     * @param button {ButtonType} - button to be pressed and released
+     * @param time {number} - time in milliseconds (defaults to 200ms)
+     */
+    pushAndReleaseButton = (button: ButtonType, time: number = 200) => {
+        this.pushButton(button);
+        setTimeout(() => this.releaseButton(button), time);
+    };
+
+    /**
+     * This method adds and configures the remote services for a give accessory.
+     *
+     * @param accessory {Accessory} - the give accessory this remote should be added to
+     */
     addServicesToAccessory = (accessory: Accessory) => {
         if (!this.targetControlManagementService || !this.targetControlService) {
-            throw new Error("Services not configured!"); // playing it save
+            throw new Error("Unexpected state: Services not configured!"); // playing it save
+        }
+        if (this.accessoryConfigured) {
+            throw new Error("Remote was already added to an accessory");
         }
 
         accessory.addService(this.targetControlManagementService);
         accessory.setPrimaryService(this.targetControlManagementService);
         accessory.addService(this.targetControlService);
+
+        if (this.audioSupported) {
+            accessory.addService(this.siriService!);
+            accessory.addService(this.audioStreamManagementService!);
+            accessory.addService(this.dataStreamManagement!.getService());
+        }
+
+        const primaryAccessory = accessory.getPrimaryAccessory();
+        primaryAccessory.on(AccessoryEventTypes.UNPAIRED, () => {
+            debug("Accessory was unpaired. Resetting targets...");
+            this.handleResetTargets(undefined);
+        });
+
+        this.accessoryConfigured = true;
     };
+
+    // ---------------------------------- CONFIGURATION ----------------------------------
+    // override methods if you would like to change anything (but should not be necessary most likely)
 
     constructSupportedConfiguration = () => {
         const configuration: SupportedConfiguration = {
             maximumTargets: 10, // some random number. (ten should be okay?)
             ticksPerSecond: 1000, // we rely on unix timestamps
             supportedButtonConfiguration: [],
-            hardwareImplemented: false // siri is only allowed for hardware implemented remotes
+            hardwareImplemented: this.audioSupported // siri is only allowed for hardware implemented remotes
         };
 
-        const supportedButtons = [ // siri button is left out
+        const supportedButtons = [
             ButtonType.MENU, ButtonType.PLAY_PAUSE, ButtonType.TV_HOME, ButtonType.SELECT,
             ButtonType.ARROW_UP, ButtonType.ARROW_RIGHT, ButtonType.ARROW_DOWN, ButtonType.ARROW_LEFT,
             ButtonType.VOLUME_UP, ButtonType.VOLUME_DOWN, ButtonType.POWER, ButtonType.GENERIC
         ];
+        if (this.audioSupported) { // add siri button if this remote supports it
+            supportedButtons.push(ButtonType.SIRI);
+        }
+
         supportedButtons.forEach(button => {
             const buttonConfiguration: SupportedButtonConfiguration = {
                 buttonID: 100 + button,
@@ -215,9 +531,268 @@ export class HomeKitRemoteController {
         return configuration;
     };
 
-    _buttonEvent = (buttonID: number, buttonState: ButtonState, timestamp: number, activeIdentifier: number) => {
-        if (activeIdentifier === 0)
-            return; // cannot press button if no device is selected
+    constructSupportedAudioConfiguration = (): SupportedAudioStreamConfiguration => {
+        // the following parameters are expected from HomeKit for a remote
+        return {
+            audioCodecConfiguration: {
+                codecType: AudioCodecTypes.OPUS,
+                parameters: {
+                    channels: 1,
+                    bitrate: AudioCodecParamBitRateTypes.VARIABLE,
+                    samplerate: AudioCodecParamSampleRateTypes.KHZ_16,
+                }
+            },
+        }
+    };
+
+    // --------------------------------- TARGET CONTROL ----------------------------------
+
+    private handleTargetControlWrite = (value: any, callback: CharacteristicSetCallback) => {
+        const data = bufferShim.from(value, 'base64');
+        const objects = tlv.decode(data);
+
+        const operation = objects[TargetControlList.OPERATION][0] as Operation;
+
+        let targetConfiguration: TargetConfiguration | undefined = undefined;
+        if (objects[TargetControlList.TARGET_CONFIGURATION]) { // if target configuration was sent, parse it
+            targetConfiguration = this.parseTargetConfigurationTLV(objects[TargetControlList.TARGET_CONFIGURATION]);
+        }
+
+        debug("Received TargetControl write operation %s", Operation[operation]);
+
+        let handler: (targetConfiguration?: TargetConfiguration) => Status;
+        switch (operation) {
+            case Operation.ADD:
+                handler = this.handleAddTarget;
+                break;
+            case Operation.UPDATE:
+                handler = this.handleUpdateTarget;
+                break;
+            case Operation.REMOVE:
+                handler = this.handleRemoveTarget;
+                break;
+            case Operation.RESET:
+                handler = this.handleResetTargets;
+                break;
+            case Operation.LIST:
+                handler = this.handleListTargets;
+                break;
+            default:
+                callback(new Error(Status.INVALID_VALUE_IN_REQUEST+""), undefined);
+                return;
+        }
+
+        const status = handler(targetConfiguration);
+        if (status === Status.SUCCESS) {
+            callback(undefined, this.targetConfigurationsString); // passing value for write response
+
+            if (operation === Operation.ADD && this.activeIdentifier === 0) {
+                this.setActiveIdentifier(targetConfiguration!.targetIdentifier);
+            }
+        } else {
+            callback(new Error(status + ""));
+        }
+    };
+
+    private handleAddTarget = (targetConfiguration?: TargetConfiguration): Status => {
+        if (!targetConfiguration) {
+            return Status.INVALID_VALUE_IN_REQUEST;
+        }
+
+        this.targetConfigurations[targetConfiguration.targetIdentifier] = targetConfiguration;
+
+        debug("Configured new target '" + targetConfiguration.targetName + "' with targetIdentifier '" + targetConfiguration.targetIdentifier + "'");
+
+        setTimeout(() => this.emit(RemoteControllerEvents.TARGET_ADDED, targetConfiguration), 0);
+
+        this.targetConfigurationsString = this.buildTargetConfigurationsTLV(this.targetConfigurations); // set response
+        return Status.SUCCESS;
+    };
+
+    private handleUpdateTarget = (targetConfiguration?: TargetConfiguration): Status => {
+        if (!targetConfiguration) {
+            return Status.INVALID_VALUE_IN_REQUEST;
+        }
+
+        const updates: TargetUpdates[] = [];
+
+        const configuredTarget = this.targetConfigurations[targetConfiguration.targetIdentifier];
+        if (targetConfiguration.targetName) {
+            debug("Target name was updated '%s' => '%s' (%d)",
+                configuredTarget.targetName, targetConfiguration.targetName, configuredTarget.targetIdentifier);
+
+            configuredTarget.targetName = targetConfiguration.targetName;
+            updates.push(TargetUpdates.NAME);
+        }
+        if (targetConfiguration.targetCategory) {
+            debug("Target category was updated '%d' => '%d' for target '%s' (%d)",
+                configuredTarget.targetCategory, targetConfiguration.targetCategory,
+                configuredTarget.targetName, configuredTarget.targetIdentifier);
+
+            configuredTarget.targetCategory = targetConfiguration.targetCategory;
+            updates.push(TargetUpdates.CATEGORY);
+        }
+        if (targetConfiguration.buttonConfiguration) {
+            debug("%d button configurations were updated for target '%s' (%d)",
+                Object.keys(targetConfiguration.buttonConfiguration).length,
+                configuredTarget.targetName, configuredTarget.targetIdentifier);
+
+            for (const key in targetConfiguration.buttonConfiguration) {
+                const configuration = targetConfiguration.buttonConfiguration[key];
+                const savedConfiguration = configuredTarget.buttonConfiguration[configuration.buttonID];
+
+                savedConfiguration.buttonType = configuration.buttonType;
+                savedConfiguration.buttonName = configuration.buttonName;
+            }
+            updates.push(TargetUpdates.UPDATED_BUTTONS);
+        }
+
+        setTimeout(() => this.emit(RemoteControllerEvents.TARGET_UPDATED, targetConfiguration, updates), 0);
+
+        this.targetConfigurationsString = this.buildTargetConfigurationsTLV(this.targetConfigurations); // set response
+        return Status.SUCCESS;
+    };
+
+    private handleRemoveTarget = (targetConfiguration?: TargetConfiguration): Status => {
+        if (!targetConfiguration) {
+            return Status.INVALID_VALUE_IN_REQUEST;
+        }
+
+        const configuredTarget = this.targetConfigurations[targetConfiguration.targetIdentifier];
+        if (!configuredTarget) {
+            return Status.INVALID_VALUE_IN_REQUEST;
+        }
+
+        if (targetConfiguration.buttonConfiguration) {
+            for (const key in targetConfiguration.buttonConfiguration) {
+                delete configuredTarget.buttonConfiguration[key];
+            }
+
+            debug("Removed %d button configurations of target '%s' (%d)",
+                Object.keys(targetConfiguration.buttonConfiguration).length, configuredTarget.targetName, configuredTarget.targetIdentifier);
+            setTimeout(() => this.emit(RemoteControllerEvents.TARGET_UPDATED, configuredTarget, [TargetUpdates.REMOVED_BUTTONS]), 0);
+        } else {
+            delete this.targetConfigurations[targetConfiguration.targetIdentifier];
+
+            debug ("Target '%s' (%d) was removed", configuredTarget.targetName, configuredTarget.targetIdentifier);
+            setTimeout(() => this.emit(RemoteControllerEvents.TARGET_REMOVED, targetConfiguration.targetIdentifier), 0);
+
+            const keys = Object.keys(this.targetConfigurations);
+            this.setActiveIdentifier(keys.length === 0? 0: parseInt(keys[0])); // switch to next available remote
+        }
+
+        this.targetConfigurationsString = this.buildTargetConfigurationsTLV(this.targetConfigurations); // set response
+        return Status.SUCCESS;
+    };
+
+    private handleResetTargets = (targetConfiguration?: TargetConfiguration): Status => {
+        if (targetConfiguration) {
+            return Status.INVALID_VALUE_IN_REQUEST;
+        }
+
+        debug("Resetting all target configurations");
+        this.targetConfigurations = {};
+
+        setTimeout(() => this.emit(RemoteControllerEvents.TARGETS_RESET), 0);
+        this.setActiveIdentifier(0); // resetting active identifier (also sets active to false)
+
+        this.targetConfigurationsString = ""; // set response
+        return Status.SUCCESS;
+    };
+
+    private handleListTargets = (targetConfiguration?: TargetConfiguration): Status => {
+        if (targetConfiguration) {
+            return Status.INVALID_VALUE_IN_REQUEST;
+        }
+
+        // this.targetConfigurationsString is updated after each change, so we basically don't need to do anything here
+        debug("Returning " + Object.keys(this.targetConfigurations).length + " target configurations");
+        return Status.SUCCESS;
+    };
+
+    private handleActiveWrite = (value: CharacteristicValue, callback: CharacteristicSetCallback, connectionID?: string) => {
+        if (!connectionID) {
+            callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
+            return;
+        }
+        const session: Session = Session.getSession(connectionID);
+        if (!session) {
+            callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
+            return;
+        }
+
+        if (this.activeIdentifier === 0) {
+            debug("Tried to change active state. There is no active target set though");
+            callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
+            return;
+        }
+
+        if (this.activeSession) {
+            this.activeSession.removeListener(HAPSessionEvents.CLOSED, this.activeSessionDisconnectionListener!);
+            this.activeSession = undefined;
+            this.activeSessionDisconnectionListener = undefined;
+        }
+
+        this.activeSession = value? session: undefined;
+        if (this.activeSession) { // register listener when hap session disconnects
+            this.activeSessionDisconnectionListener = this.handleActiveSessionDisconnected.bind(this, this.activeSession);
+            this.activeSession.on(HAPSessionEvents.CLOSED, this.activeSessionDisconnectionListener);
+        }
+
+        const activeName = this.targetConfigurations[this.activeIdentifier].targetName;
+        debug("Remote with activeTarget '%s' (%d) was set to %s", activeName, this.activeIdentifier, value ? "ACTIVE" : "INACTIVE");
+
+        callback();
+
+        this.emit(RemoteControllerEvents.ACTIVE_CHANGE, value as boolean);
+    };
+
+    private setInactive = () => {
+        if (this.activeSession === undefined) {
+            return;
+        }
+
+        this.activeSession.removeListener(HAPSessionEvents.CLOSED, this.activeSessionDisconnectionListener!);
+        this.activeSession = undefined;
+        this.activeSessionDisconnectionListener = undefined;
+
+        this.targetControlService!.getCharacteristic(Characteristic.Active)!.updateValue(false);
+        debug("Remote was set to INACTIVE");
+
+        setTimeout(() => this.emit(RemoteControllerEvents.ACTIVE_CHANGE, false), 0);
+    };
+
+    private handleActiveSessionDisconnected = (session: Session) => {
+        if (session !== this.activeSession) {
+            return;
+        }
+
+        debug("Active hap session disconnected!");
+        this.setInactive();
+    };
+
+    private sendButtonEvent = (button: ButtonType, buttonState: ButtonState) => {
+        const buttonID = this.buttons[button];
+        if (buttonID === undefined || buttonID === 0) {
+            throw new Error("Tried sending button event for unsupported button (" + button + ")");
+        }
+
+        if (this.activeIdentifier === 0) { // cannot press button if no device is selected
+            throw new Error("Tried sending button event although no target was selected");
+        }
+
+        if (!this.isActive()) { // cannot press button if device is not active (aka no apple tv is listening)
+            throw new Error("Tried sending button event although target was not marked as active");
+        }
+
+        if (button === ButtonType.SIRI && this.audioSupported) {
+            if (buttonState === ButtonState.DOWN) { // start streaming session
+                this.handleSiriAudioStart();
+            } else if (buttonState === ButtonState.UP) { // stop streaming session
+                this.handleSiriAudioStop();
+            }
+            return;
+        }
 
         const buttonIdTlv = tlv.encode(
             ButtonEvent.BUTTON_ID, buttonID
@@ -228,13 +803,13 @@ export class HomeKitRemoteController {
         );
 
         const timestampTlv = tlv.encode(
-            ButtonEvent.TIMESTAMP, tlv.writeUInt64(timestamp)
+            ButtonEvent.TIMESTAMP, tlv.writeUInt64(new Date().getTime())
             // timestamp should be uint64. bigint though is only supported by node 10.4.0 and above
             // thus we just interpret timestamp as a regular number
         );
 
         const activeIdentifierTlv = tlv.encode(
-            ButtonEvent.ACTIVE_IDENTIFIER, tlv.writeUInt32(activeIdentifier)
+            ButtonEvent.ACTIVE_IDENTIFIER, tlv.writeUInt32(this.activeIdentifier)
         );
 
         this.lastButtonEvent = Buffer.concat([
@@ -243,71 +818,7 @@ export class HomeKitRemoteController {
         this.targetControlService!.getCharacteristic(Characteristic.ButtonEvent)!.updateValue(this.lastButtonEvent);
     };
 
-    _handleTargetControlWrite = (value: any, callback: CharacteristicSetCallback) => {
-        const data = bufferShim.from(value, 'base64');
-        const objects = tlv.decode(data);
-
-        const operation = objects[TargetControlList.OPERATION][0];
-
-        let targetConfiguration: TargetConfiguration | undefined = undefined;
-        if (objects[TargetControlList.TARGET_CONFIGURATION]) { // if target configuration was sent, parse it
-            targetConfiguration = this._parseTargetConfiguration(objects[TargetControlList.TARGET_CONFIGURATION]);
-        }
-
-        debug("Received TargetControl write operation %s%s", Operation[operation], targetConfiguration !== undefined
-            ? "with configuration: " + JSON.stringify(targetConfiguration)
-            : "");
-
-        if (targetConfiguration === undefined && (operation === Operation.ADD || operation === Operation.UPDATE || operation === Operation.REMOVE)) {
-            callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
-            return;
-        } else if (targetConfiguration && (operation === Operation.LIST || operation === Operation.RESET)) {
-            callback(new Error(Status.INVALID_VALUE_IN_REQUEST + ""));
-            return;
-        }
-
-        switch (operation) {
-            case Operation.ADD:
-                this.targetConfigurations[targetConfiguration!.targetIdentifier] = targetConfiguration!;
-
-                this.targetConfigurationsString = this._targetConfigurations(this.targetConfigurations);
-                break;
-            case Operation.UPDATE:
-                // update only seems to update button configuration, leaving out names and category
-                // for me it always removes the volume buttons from the configuration. Why, i don't know
-
-                const savedTargetConfiguration = this.targetConfigurations[targetConfiguration!.targetIdentifier];
-                if (targetConfiguration!.targetName)
-                    savedTargetConfiguration.targetName = targetConfiguration!.targetName;
-                if (targetConfiguration!.targetCategory)
-                    savedTargetConfiguration.targetCategory = targetConfiguration!.targetCategory;
-                if (targetConfiguration!.buttonConfiguration)
-                    savedTargetConfiguration.buttonConfiguration = targetConfiguration!.buttonConfiguration;
-
-                this.targetConfigurationsString = this._targetConfigurations(this.targetConfigurations);
-                break;
-            case Operation.REMOVE:
-                delete this.targetConfigurations[targetConfiguration!.targetIdentifier];
-
-                this.targetConfigurationsString = this._targetConfigurations(this.targetConfigurations);
-                break;
-            case Operation.RESET:
-                this.targetConfigurations = {};
-                this.targetConfigurationsString = "";
-                break;
-            case Operation.LIST:
-                this.targetConfigurationsString = this._targetConfigurations(this.targetConfigurations);
-                break;
-        }
-
-        callback(undefined, this.targetConfigurationsString); // passing value for write response
-        debug("Returning target configuration: " + this.targetConfigurationsString);
-
-        if (operation === Operation.ADD)
-            this.setActiveIdentifier(targetConfiguration!.targetIdentifier);
-    };
-
-    _parseTargetConfiguration = (data: Buffer) => {
+    private parseTargetConfigurationTLV = (data: Buffer): TargetConfiguration => {
         const configTLV = tlv.decode(data);
 
         const identifier = tlv.readUInt32(configTLV[TargetConfigurationTypes.TARGET_IDENTIFIER]);
@@ -320,7 +831,7 @@ export class HomeKitRemoteController {
         if (configTLV[TargetConfigurationTypes.TARGET_CATEGORY])
             category = tlv.readUInt16(configTLV[TargetConfigurationTypes.TARGET_CATEGORY]);
 
-        const buttonConfiguration: ButtonConfiguration[] = [];
+        const buttonConfiguration: Record<number, ButtonConfiguration> = {};
 
         if (configTLV[TargetConfigurationTypes.BUTTON_CONFIGURATION]) {
             const buttonConfigurationTLV = tlv.decodeList(configTLV[TargetConfigurationTypes.BUTTON_CONFIGURATION], ButtonConfigurationTypes.BUTTON_ID);
@@ -328,14 +839,17 @@ export class HomeKitRemoteController {
                 const buttonId = entry[ButtonConfigurationTypes.BUTTON_ID][0];
                 const buttonType = tlv.readUInt16(entry[ButtonConfigurationTypes.BUTTON_TYPE]);
                 let buttonName;
-                if (entry[ButtonConfigurationTypes.BUTTON_NAME])
+                if (entry[ButtonConfigurationTypes.BUTTON_NAME]) {
                     buttonName = entry[ButtonConfigurationTypes.BUTTON_NAME].toString();
+                } else {
+                    buttonName = ButtonType[buttonType as ButtonType];
+                }
 
-                buttonConfiguration.push({
+                buttonConfiguration[buttonId] = {
                     buttonID: buttonId,
                     buttonType: buttonType,
                     buttonName: buttonName
-                })
+                };
             });
         }
 
@@ -344,10 +858,10 @@ export class HomeKitRemoteController {
             targetName: name,
             targetCategory: category,
             buttonConfiguration: buttonConfiguration
-        } as TargetConfiguration;
+        };
     };
 
-    _targetConfigurations = (configurations: Record<number, TargetConfiguration>) => {
+    private buildTargetConfigurationsTLV = (configurations: Record<number, TargetConfiguration>) => {
         const bufferList = [];
         for (const key in configurations) {
             // noinspection JSUnfilteredForInLoop
@@ -366,7 +880,7 @@ export class HomeKitRemoteController {
             );
 
             const buttonConfigurationBuffers: Buffer[] = [];
-            configuration.buttonConfiguration.forEach(value => {
+            Object.values(configuration.buttonConfiguration).forEach(value => {
                 let tlvBuffer = tlv.encode(
                     ButtonConfigurationTypes.BUTTON_ID, value.buttonID,
                     ButtonConfigurationTypes.BUTTON_TYPE, tlv.writeUInt16(value.buttonType)
@@ -398,7 +912,7 @@ export class HomeKitRemoteController {
         return Buffer.concat(bufferList).toString('base64');
     };
 
-    _targetControlSupportedConfiguration = (configuration: SupportedConfiguration) => {
+    private buildTargetControlSupportedConfigurationTLV = (configuration: SupportedConfiguration) => {
         const maximumTargets = tlv.encode(
             TargetControlCommands.MAXIMUM_TARGETS, configuration.maximumTargets
         );
@@ -419,12 +933,192 @@ export class HomeKitRemoteController {
             TargetControlCommands.SUPPORTED_BUTTON_CONFIGURATION, Buffer.concat(supportedButtonConfigurationBuffers)
         );
 
-        const type = tlv.encode(TargetControlCommands.TYPE, configuration.hardwareImplemented? 1: 0);
+        const type = tlv.encode(TargetControlCommands.TYPE, configuration.hardwareImplemented ? 1 : 0);
 
         return Buffer.concat(
             [maximumTargets, ticksPerSecond, supportedButtonConfiguration, type]
         ).toString('base64');
     };
+
+    // --------------------------------- SIRI/DATA STREAM --------------------------------
+
+    private handleTargetControlWhoAmI = (connection: DataStreamConnection, message: Record<any, any>) => {
+        const targetIdentifier = message["identifier"];
+        this.dataStreamConnections[targetIdentifier] = connection;
+        debug("Discovered HDS connection for targetIdentifier %s", targetIdentifier);
+
+        connection.addProtocolHandler(Protocols.DATA_SEND, this);
+    };
+
+    private handleSiriAudioStart = () => {
+        if (!this.audioSupported) {
+            throw new Error("Cannot start siri stream on remote where siri is not supported");
+        }
+
+        if (!this.isActive()) {
+            debug("Tried opening Siri audio stream, however no controller is connected!");
+            return;
+        }
+
+        if (this.activeAudioSession && (!this.activeAudioSession.isClosing() || this.nextAudioSession)) {
+            // there is already a session running, which is not in closing state and/or there is even already a
+            // nextAudioSession running. ignoring start request
+            debug("Tried opening Siri audio stream, however there is already one in progress");
+            return;
+        }
+
+        const connection = this.dataStreamConnections[this.activeIdentifier]; // get connection for current target
+        if (connection === undefined) { // target seems not connected, ignore it
+            debug("Tried opening Siri audio stream however target is not connected via HDS");
+            return;
+        }
+
+        const audioSession = new SiriAudioSession(connection, this.selectedAudioConfiguration, this.audioProducerConstructor!, this.audioProducerOptions);
+        if (!this.activeAudioSession) {
+            this.activeAudioSession = audioSession;
+        } else {
+            // we checked above that this only happens if the activeAudioSession is in closing state,
+            // so no collision with the input device can happen
+            this.nextAudioSession = audioSession;
+        }
+
+        audioSession.on(SiriAudioSessionEvents.CLOSE, this.handleSiriAudioSessionClosed.bind(this, audioSession));
+        audioSession.start();
+    };
+
+    private handleSiriAudioStop = () => {
+        if (this.activeAudioSession) {
+            if (!this.activeAudioSession.isClosing()) {
+                this.activeAudioSession.stop();
+                return;
+            } else if (this.nextAudioSession && !this.nextAudioSession.isClosing()) {
+                this.nextAudioSession.stop();
+                return;
+            }
+        }
+
+        debug("handleSiriAudioStop called although no audio session was started");
+    };
+
+    private handleDataSendAckEvent = (message: Record<any, any>) => { // transfer was successful
+        const streamId = message["streamId"];
+        const endOfStream = message["endOfStream"];
+
+        if (this.activeAudioSession && this.activeAudioSession.streamId === streamId) {
+            this.activeAudioSession.handleDataSendAckEvent(endOfStream);
+        } else if (this.nextAudioSession && this.nextAudioSession.streamId === streamId) {
+            this.nextAudioSession.handleDataSendAckEvent(endOfStream);
+        } else {
+            debug("Received dataSend acknowledgment event for unknown streamId '%s'", streamId);
+        }
+    };
+
+    private handleDataSendCloseEvent = (message: Record<any, any>) => { // controller indicates he can't handle audio request currently
+        const streamId = message["streamId"];
+        const reason = message["reason"] as DataSendCloseReason;
+
+        if (this.activeAudioSession && this.activeAudioSession.streamId === streamId) {
+            this.activeAudioSession.handleDataSendCloseEvent(reason);
+        } else if (this.nextAudioSession && this.nextAudioSession.streamId === streamId) {
+            this.nextAudioSession.handleDataSendCloseEvent(reason);
+        } else {
+            debug("Received dataSend close event for unknown streamId '%s'", streamId);
+        }
+    };
+
+    private handleSiriAudioSessionClosed = (session: SiriAudioSession) => {
+        if (session === this.activeAudioSession) {
+            this.activeAudioSession = this.nextAudioSession;
+            this.nextAudioSession = undefined;
+        } else if (session === this.nextAudioSession) {
+            this.nextAudioSession = undefined;
+        }
+    };
+
+    private handleDataStreamConnectionClosed = (connection: DataStreamConnection) => {
+        for (const targetIdentifier in this.dataStreamConnections) {
+            const connection0 = this.dataStreamConnections[targetIdentifier];
+            if (connection === connection0) {
+                debug("HDS connection disconnected for targetIdentifier %s", targetIdentifier);
+                delete this.dataStreamConnections[targetIdentifier];
+                break;
+            }
+        }
+    };
+
+    // ------------------------------- AUDIO CONFIGURATION -------------------------------
+
+    private handleSelectedAudioConfigurationWrite = (value: any, callback: CharacteristicSetCallback) => {
+        const data = bufferShim.from(value, 'base64');
+        const objects = tlv.decode(data);
+
+        const selectedAudioStreamConfiguration = tlv.decode(
+            objects[SelectedAudioInputStreamConfigurationTypes.SELECTED_AUDIO_INPUT_STREAM_CONFIGURATION]
+        );
+
+        const codec = selectedAudioStreamConfiguration[AudioTypes.CODEC][0];
+        const parameters = tlv.decode(selectedAudioStreamConfiguration[AudioTypes.CODEC_PARAM]);
+
+        const channels = parameters[AudioCodecParamTypes.CHANNEL][0];
+        const bitrate = parameters[AudioCodecParamTypes.BIT_RATE][0];
+        const samplerate = parameters[AudioCodecParamTypes.SAMPLE_RATE][0];
+
+        this.selectedAudioConfiguration = {
+            codecType: codec,
+            parameters: {
+                channels: channels,
+                bitrate: bitrate,
+                samplerate: samplerate,
+                rtpTime: 20
+            }
+        };
+        this.selectedAudioConfigurationString = this.buildSelectedAudioConfigurationTLV({
+            audioCodecConfiguration: this.selectedAudioConfiguration,
+        });
+
+        callback();
+    };
+
+    private buildSupportedAudioConfigurationTLV = (configuration: SupportedAudioStreamConfiguration) => {
+        const codecConfigurationTLV = this.buildCodecConfigurationTLV(configuration.audioCodecConfiguration);
+
+        const supportedAudioStreamConfiguration = tlv.encode(
+            SupportedAudioStreamConfigurationTypes.AUDIO_CODEC_CONFIGURATION, codecConfigurationTLV
+        );
+        return supportedAudioStreamConfiguration.toString('base64');
+    };
+
+    private buildSelectedAudioConfigurationTLV = (configuration: SelectedAudioStreamConfiguration) => {
+        const codecConfigurationTLV = this.buildCodecConfigurationTLV(configuration.audioCodecConfiguration);
+
+        const supportedAudioStreamConfiguration = tlv.encode(
+            SelectedAudioInputStreamConfigurationTypes.SELECTED_AUDIO_INPUT_STREAM_CONFIGURATION, codecConfigurationTLV,
+        );
+        return supportedAudioStreamConfiguration.toString('base64');
+    };
+
+    private buildCodecConfigurationTLV = (codecConfiguration: AudioCodecConfiguration) => {
+        const parameters = codecConfiguration.parameters;
+
+        let parametersTLV = tlv.encode(
+            AudioCodecParamTypes.CHANNEL, parameters.channels,
+            AudioCodecParamTypes.BIT_RATE, parameters.bitrate,
+            AudioCodecParamTypes.SAMPLE_RATE, parameters.samplerate,
+        );
+        if (parameters.rtpTime) {
+            parametersTLV = Buffer.concat([
+                parametersTLV,
+                tlv.encode(AudioCodecParamTypes.PACKET_TIME, parameters.rtpTime)
+            ]);
+        }
+
+        return tlv.encode(
+            AudioTypes.CODEC, codecConfiguration.codecType,
+            AudioTypes.CODEC_PARAM, parametersTLV
+        );
+    };
+
+    // -----------------------------------------------------------------------------------
 
     _createServices = () => {
         this.targetControlManagementService = new Service.TargetControlManagement('', '');
@@ -437,7 +1131,7 @@ export class HomeKitRemoteController {
                 callback(null, this.targetConfigurationsString);
             })
             .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                this._handleTargetControlWrite(value, callback);
+                this.handleTargetControlWrite(value, callback);
             }).getValue();
 
         // you can also expose multiple TargetControl services to control multiple apple tvs simultaneously.
@@ -449,54 +1143,298 @@ export class HomeKitRemoteController {
             }).getValue();
         this.targetControlService.getCharacteristic(Characteristic.Active)!
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.active);
+                callback(undefined, this.isActive());
             })
-            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                this.active = value as boolean;
-                callback();
+            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback, context?: any, connectionID?: string) => {
+                this.handleActiveWrite(value, callback, connectionID);
             }).getValue();
         this.targetControlService.getCharacteristic(Characteristic.ButtonEvent)!
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 callback(undefined, this.lastButtonEvent);
             }).getValue();
 
-        /* The following characteristics are need for Siri support and the implementation of HomeKit Data Streams
-        const siriService = new Service.Siri('', '');
-        siriService.getCharacteristic(Characteristic.SiriInputType)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-               callback(undefined, 0); // push button triggered Apple TV
-            });
+        if (this.audioSupported) {
+            this.siriService = new Service.Siri('', '');
+            this.siriService.getCharacteristic(Characteristic.SiriInputType)!
+                .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                    callback(undefined, SiriInputType.PUSH_BUTTON_TRIGGERED_APPLE_TV);
+                });
 
-        const dataStreamTransportManagement = new Service.DataStreamTransportManagement('', '');
-        dataStreamTransportManagement.getCharacteristic(Characteristic.SupportedDataStreamTransportConfiguration)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, "");
-            });
-        dataStreamTransportManagement.getCharacteristic(Characteristic.SetupDataStreamTransport)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(null, "");
-            })
-            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                const writeResponse = "";
-                callback(null, writeResponse);
-            }).getValue();
-        dataStreamTransportManagement.getCharacteristic(Characteristic.Version)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, "1.0");
-            });
+            this.audioStreamManagementService = new Service.AudioStreamManagement('', '');
+            this.audioStreamManagementService.getCharacteristic(Characteristic.SupportedAudioStreamConfiguration)!
+                .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                    callback(undefined, this.supportedAudioConfiguration);
+                }).getValue();
+            this.audioStreamManagementService.getCharacteristic(Characteristic.SelectedAudioStreamConfiguration)!
+                .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                    callback(null, this.selectedAudioConfigurationString);
+                })
+                .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                    this.handleSelectedAudioConfigurationWrite(value, callback);
+                }).getValue();
 
-        const audioStreamManagement = new Service.AudioStreamManagement('', '');
-        audioStreamManagement.getCharacteristic(Characteristic.SupportedAudioStreamConfiguration)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, "");
-            });
-        audioStreamManagement.getCharacteristic(Characteristic.SelectedAudioStreamConfiguration)!
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(null, "");
-            })
-            .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                callback();
-            }).getValue();
-        */
+            this.dataStreamManagement = new DataStreamManagement();
+
+            this.siriService.addLinkedService(this.dataStreamManagement.getService());
+            this.siriService.addLinkedService(this.audioStreamManagementService);
+        }
     }
+}
+
+export enum SiriAudioSessionEvents {
+    CLOSE = "close",
+}
+
+export type SiriAudioSessionEventMap = {
+    [SiriAudioSessionEvents.CLOSE]: () => void;
+}
+
+/**
+ * Represents an ongoing audio transmission
+ */
+export class SiriAudioSession extends EventEmitter<SiriAudioSessionEventMap> {
+
+    readonly connection: DataStreamConnection;
+    private readonly selectedAudioConfiguration: AudioCodecConfiguration;
+
+    private readonly producer: SiriAudioStreamProducer;
+    private producerRunning = false; // indicates if the producer is running
+    private producerTimer?: Timeout; // producer has a 3s timeout to produce the first frame, otherwise transmission will be cancelled
+
+    state: SiriAudioSessionState = SiriAudioSessionState.STARTING;
+    streamId?: number; // present when state >= SENDING
+    endOfStream: boolean = false;
+
+    private audioFrameQueue: AudioFrame[] = [];
+    private readonly maxQueueSize = 1024;
+    private sequenceNumber: number = 0;
+
+    private readonly closeListener: () => void;
+
+    constructor(connection: DataStreamConnection, selectedAudioConfiguration: AudioCodecConfiguration, producerConstructor: SiriAudioStreamProducerConstructor, producerOptions?: any) {
+        super();
+        this.connection = connection;
+        this.selectedAudioConfiguration = selectedAudioConfiguration;
+
+        this.producer = new producerConstructor(this.handleSiriAudioFrame.bind(this), this.handleProducerError.bind(this), producerOptions);
+
+        this.connection.on(DataStreamConnectionEvents.CLOSED, this.closeListener = this.handleDataStreamConnectionClosed.bind(this));
+    }
+
+    /**
+     * Called when siri button is pressed
+     */
+    start() {
+        debug("Sending request to start siri audio stream");
+
+        // opening dataSend
+        this.connection.sendRequest(Protocols.DATA_SEND, Topics.OPEN, {
+            target: "controller",
+            type: "audio.siri"
+        }, (error, status, message) => {
+            if (this.state === SiriAudioSessionState.CLOSED) {
+                debug("Ignoring dataSend open response as the session is already closed");
+                return;
+            }
+
+            assert.strictEqual(this.state, SiriAudioSessionState.STARTING);
+            this.state = SiriAudioSessionState.SENDING;
+
+            if (error || status) {
+                if (error) { // errors get produced by hap-nodejs
+                    debug("Error occurred trying to start siri audio stream: %s", error.message);
+                } else if (status) { // status codes are those returned by the hds response
+                    debug("Controller responded with non-zero status code: %d", status);
+                }
+                this.closed();
+            } else {
+                this.streamId = message["streamId"];
+
+                if (!this.producerRunning) { // audio producer errored in the meantime
+                    this.sendDataSendCloseEvent(DataSendCloseReason.CANCELLED);
+                } else {
+                    debug("Successfully setup siri audio stream with streamId %d", this.streamId);
+                }
+            }
+        });
+
+        this.startAudioProducer(); // start audio producer and queue frames in the meantime
+    }
+
+    /**
+     * @returns if the audio session is closing
+     */
+    isClosing() {
+        return this.state >= SiriAudioSessionState.CLOSING;
+    }
+
+    /**
+     * Called when siri button is released (or active identifier is changed to another device)
+     */
+    stop() {
+        assert(this.state <= SiriAudioSessionState.SENDING, "state was higher than SENDING");
+
+        debug("Stopping siri audio stream with streamId %d", this.streamId);
+
+        this.endOfStream = true; // mark as endOfStream
+        this.stopAudioProducer();
+
+        if (this.state === SiriAudioSessionState.SENDING) {
+            this.handleSiriAudioFrame(undefined); // send out last few audio frames with endOfStream property set
+
+            this.state = SiriAudioSessionState.CLOSING; // we are waiting for an acknowledgment (triggered by endOfStream property)
+        } else { // if state is not SENDING (aka state is STARTING) the callback for DATA_SEND OPEN did not yet return (or never will)
+            this.closed();
+        }
+    }
+
+    private startAudioProducer() {
+        this.producer.startAudioProduction(this.selectedAudioConfiguration);
+        this.producerRunning = true;
+
+        this.producerTimer = setTimeout(() => { // producer has 3s to start producing audio frames
+            debug("Didn't receive any frames from audio producer for stream with streamId %s. Canceling the stream now.", this.streamId);
+            this.producerTimer = undefined;
+            this.handleProducerError(DataSendCloseReason.CANCELLED);
+        }, 3000);
+    }
+
+    private stopAudioProducer() {
+        this.producer.stopAudioProduction();
+        this.producerRunning = false;
+
+        if (this.producerTimer) {
+            clearTimeout(this.producerTimer);
+            this.producerTimer = undefined;
+        }
+    }
+
+    private handleSiriAudioFrame = (frame?: AudioFrame) => { // called from audio producer
+        if (this.state >= SiriAudioSessionState.CLOSING) {
+            return;
+        }
+
+        if (this.producerTimer) { // if producerTimer is defined, then this is the first frame we are receiving
+            clearTimeout(this.producerTimer);
+            this.producerTimer = undefined;
+        }
+
+        if (frame && this.audioFrameQueue.length < this.maxQueueSize) { // add frame to queue whilst it is not full
+            this.audioFrameQueue.push(frame);
+        }
+
+        if (this.state !== SiriAudioSessionState.SENDING) { // dataSend isn't open yet
+            return;
+        }
+
+        let queued;
+        while ((queued = this.popSome()) !== null) { // send packets
+            const packets: AudioFramePacket[] = [];
+            queued.forEach(frame => {
+                const packetData: AudioFramePacket = {
+                    data: frame.data,
+                    metadata: {
+                        rms: new Float32(frame.rms),
+                        sequenceNumber: new Int64(this.sequenceNumber++),
+                    }
+                };
+                packets.push(packetData);
+            });
+
+            const message: DataSendMessageData = {
+                packets: packets,
+                streamId: new Int64(this.streamId!),
+                endOfStream: this.endOfStream,
+            };
+
+            try {
+                this.connection.sendEvent(Protocols.DATA_SEND, Topics.DATA, message);
+            } catch (error) {
+                debug("Error occurred when trying to send audio frame of hds connection: %s", error.message);
+
+                this.stopAudioProducer();
+                this.closed();
+            }
+
+            if (this.endOfStream) {
+                break; // popSome() returns empty list if endOfStream=true
+            }
+        }
+    };
+
+    private handleProducerError = (error: DataSendCloseReason) => { // called from audio producer
+        if (this.state >= SiriAudioSessionState.CLOSING) {
+            return;
+        }
+
+        this.stopAudioProducer(); // ensure backend is closed
+        if (this.state === SiriAudioSessionState.SENDING) { // if state is less than sending dataSend isn't open (yet)
+            this.sendDataSendCloseEvent(error); // cancel submission
+        }
+    };
+
+    handleDataSendAckEvent = (endOfStream: boolean) => { // transfer was successful
+        assert.strictEqual(endOfStream, true);
+
+        debug("Received acknowledgment for siri audio stream with streamId %s, closing it now", this.streamId);
+
+        this.sendDataSendCloseEvent(DataSendCloseReason.NORMAL);
+    };
+
+    handleDataSendCloseEvent = (reason: DataSendCloseReason) => { // controller indicates he can't handle audio request currently
+        debug("Received close event from controller with reason %s for stream with streamId %s", DataSendCloseReason[reason], this.streamId);
+        if (this.state <= SiriAudioSessionState.SENDING) {
+            this.stopAudioProducer();
+        }
+
+        this.closed();
+    };
+
+    private sendDataSendCloseEvent = (reason: DataSendCloseReason) => {
+        assert(this.state >= SiriAudioSessionState.SENDING, "state was less than SENDING");
+        assert(this.state <= SiriAudioSessionState.CLOSING, "state was higher than CLOSING");
+
+        this.connection.sendEvent(Protocols.DATA_SEND, Topics.CLOSE, {
+            streamId: new Int64(this.streamId!),
+            reason: new Int64(reason),
+        });
+
+        this.closed();
+    };
+
+    private handleDataStreamConnectionClosed = () => {
+        debug("Closing audio session with streamId %d", this.streamId);
+
+        if (this.state <= SiriAudioSessionState.SENDING) {
+            this.stopAudioProducer();
+        }
+
+        this.closed();
+    };
+
+    private closed = () => {
+        const lastState = this.state;
+        this.state = SiriAudioSessionState.CLOSED;
+
+        if (lastState !== SiriAudioSessionState.CLOSED) {
+            this.emit(SiriAudioSessionEvents.CLOSE);
+            this.connection.removeListener(DataStreamConnectionEvents.CLOSED, this.closeListener);
+        }
+    };
+
+    private popSome() { // tries to return 5 elements from the queue, if endOfStream=true also less than 5
+        if (this.audioFrameQueue.length < 5 && !this.endOfStream) {
+            return null;
+        }
+
+        const size = Math.min(this.audioFrameQueue.length, 5); // 5 frames per hap packet seems fine
+        const result = [];
+        for (let i = 0; i < size; i++) {
+            const element = this.audioFrameQueue.shift()!; // removes first element
+            result.push(element);
+        }
+
+        return result;
+    }
+
 }

--- a/src/lib/datastream/DataStreamServer.ts
+++ b/src/lib/datastream/DataStreamServer.ts
@@ -65,7 +65,7 @@ export enum DataSendCloseReason {
     NORMAL = 0,
     NOT_ALLOWED = 1,
     BUSY = 2,
-    CANCELLED = 4,
+    CANCELLED = 3,
     UNSUPPORTED = 4,
     UNEXPECTED_FAILURE = 5,
     TIMEOUT = 6,


### PR DESCRIPTION
This part two of two (with part one being #736 and thus also containing the changes of the previous PR).

In this PR support for Siri voice input has been added. The provided example plugin was extended to show how supporting voice data is going to work (by default turned off). The only thing which you need to define is audio producer object, which generates individual opus frames (according to the supplied audio configuration) and calls the respective handler to send them out. I decided to include an example implementation which uses gstreamer and `alsasrc` (as most of the people run hap-nodejs on raspberry pis anyway. A implementation using `osxaudiosrc` would also be possible. However I couldn't get gstreamer to record any audio under macOS Catalina when executing gstreamer directly via terminal).

Also in this PR:
* The remote controller is generally more robust and fixed some issues (most importantly stuff related to updating button configurations)
* Additionally added some events to the remote controller class so it can be properly integrated into UI, devices, etc
* Added an `PAIRED` and `UNPAIRED` event to the Accessory class (`UNPAIRED` is the important one as it is used to reset the target configuration of the remote)

Note: For homebridge users the current implementation is a bit limiting. It requires an implementation via a homebridge platform plugin, as the `addServicesToAccessory(...)` method requires a reference to the accessory in order to correctly configure the services and events. This is problematic since simple homebridge plugins do not have a reference to the accessory instance.