### PR TITLE
Add missing type cast to fix TypeScript build.

### DIFF
--- a/src/lib/gen/importAsClasses.ts
+++ b/src/lib/gen/importAsClasses.ts
@@ -179,7 +179,7 @@ function getCharacteristicFormatsKey(format: string) {
 
   // look up the key in our known-formats dict
   for (var key in Formats)
-    if (Formats[key] == format)
+    if (Formats[key as keyof typeof Formats] == format)
       return key;
 
   throw new Error("Unknown characteristic format '" + format + "'");
@@ -188,7 +188,7 @@ function getCharacteristicFormatsKey(format: string) {
 function getCharacteristicUnitsKey(units: string) {
   // look up the key in our known-units dict
   for (var key in Units)
-    if (Units[key] == units)
+    if (Units[key as keyof typeof Units] == units)
       return key;
 
   throw new Error("Unknown characteristic units '" + units + "'");


### PR DESCRIPTION
Currently, building via `tsc` fails due to two missing type casts in `importAsClasses.ts` -> this doesn't affect running via `ts-node`, because the affected code is apparently not used anywhere else.

However, since the switch to TypeScript, building before running is quite advisable on embedded platforms (RPI et al.), since `ts-node` is incredibly slow there.

This pull requests adds the missing casts, so that `tsc` finishes without errors.

Also see #734 