### PR TITLE
Fix unpublish function to close all open connections and allow republish

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -623,8 +623,13 @@ export class Accessory extends EventEmitter<Events> {
    *                                new Accessory.
    */
   publish = (info: PublishInfo, allowInsecureRequest?: boolean) => {
-    this.addService(Service.ProtocolInformation) // add the protocol information service to the primary accessory
-        .setCharacteristic(Characteristic.Version, Advertiser.protocolVersionService);
+    let service: Service | undefined;
+
+    service = this.getService(Service.ProtocolInformation);
+    if (!service) {
+      service = this.addService(Service.ProtocolInformation) // add the protocol information service to the primary accessory
+    }
+    service.setCharacteristic(Characteristic.Version, Advertiser.protocolVersionService);
 
     // attempt to load existing AccessoryInfo from disk
     this._accessoryInfo = AccessoryInfo.load(info.username);

--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -101,6 +101,9 @@ export class EventedHTTPServer extends EventEmitter<Events> {
 
   stop = () => {
     this._tcpServer.close();
+    this._connections.forEach((connection) => {
+      connection.close();
+    });
     this._connections = [];
   }
 
@@ -339,6 +342,10 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
       this._pendingEventData = Buffer.concat([this._pendingEventData, data]);
     else
       this._clientSocket.write(data);
+  }
+
+  close = () => {
+    this._clientSocket.end();
   }
 
   _sendPendingEvents = () => {


### PR DESCRIPTION
After calling unpublish the HTTP server will be stopped but all clients stay connected which you can see if you call netstat. Any data which will be sent from those connected clients will still be processed even though the bridge should not be published anymore at this point. The process must be killed to close those open connections.

This makes it impossible to unpublish and republish a bridge. Furthermore the publish method cannot be called again because the ProtocolInformation service will be added again. The application needs to be restarted in order to be able to publish the bridge again.

Those issues lead to the issue described under https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/12 where it is not possible to redeploy a bridge node in Node-RED by calling unpublish and creating a new bridge instance.