### PR TITLE
Automatically update configuration after specific characteristics change

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -267,6 +267,16 @@ export class Accessory extends EventEmitter<Events> {
       if (!this.bridged)
         this._handleCharacteristicChange(clone(change, {accessory:this, service:service as Service}));
 
+      // if the characteristic is configured to cause a config update, then
+      // the configuration of the bridge will be updated which will inform the
+      // clients about the change
+      if (change.characteristic.props.configUpdate) {
+        if (this.bridge) {
+          this.bridge._updateConfiguration();
+        } else {
+          this._updateConfiguration();
+        }
+      }
     });
 
     return service;

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -67,6 +67,7 @@ export interface CharacteristicProps {
   maxDataLen?: number;
   validValues?: number[];
   validValueRanges?: [number, number];
+  configUpdate?: boolean;
 }
 
 export enum Access {
@@ -361,6 +362,7 @@ export class Characteristic extends EventEmitter<Events> {
       minValue: null,
       maxValue: null,
       minStep: null,
+      configUpdate: false, // default to no update
       perms: []
     };
   }
@@ -382,6 +384,7 @@ export class Characteristic extends EventEmitter<Events> {
    *   maxDataLen: <max length of data>, (Optional default: 2097152)
    *   valid-values: <array of numbers>, (Optional)
    *   valid-values-range: <array of two numbers for start and end range> (Optional)
+   *   configUpdate: <if set to true a change will update the config> (Optional)
    * }
    */
   setProps = (props: CharacteristicProps) => {
@@ -733,8 +736,9 @@ export class Characteristic extends EventEmitter<Events> {
     // if we're not readable, omit the "value" property - otherwise iOS will complain about non-compliance
     if (this.props.perms.indexOf(Perms.READ) == -1)
       delete hap.value;
-    // delete the "value" property anyway if we were asked to
-    if (opt && opt.omitValues)
+    // delete the "value" property anyway if we were asked to and if the
+    // characteristic is not supposed to cause an update of the configuration
+    if (opt && opt.omitValues && !this.props.configUpdate)
       delete hap.value;
     return hap as HapCharacteristic;
   }

--- a/src/lib/gen/HomeKit.ts
+++ b/src/lib/gen/HomeKit.ts
@@ -934,6 +934,7 @@ export class FirmwareRevision extends Characteristic {
     super('Firmware Revision', FirmwareRevision.UUID);
     this.setProps({
       format: Formats.STRING,
+      configUpdate: true,
       perms: [Perms.READ]
     });
     this.value = this.getDefaultValue();
@@ -1365,6 +1366,7 @@ export class Manufacturer extends Characteristic {
     super('Manufacturer', Manufacturer.UUID);
     this.setProps({
       format: Formats.STRING,
+      configUpdate: true,
       perms: [Perms.READ]
     });
     this.value = this.getDefaultValue();
@@ -1385,6 +1387,7 @@ export class Model extends Characteristic {
     super('Model', Model.UUID);
     this.setProps({
       format: Formats.STRING,
+      configUpdate: true,
       perms: [Perms.READ]
     });
     this.value = this.getDefaultValue();
@@ -1445,6 +1448,7 @@ export class Name extends Characteristic {
     super('Name', Name.UUID);
     this.setProps({
       format: Formats.STRING,
+      configUpdate: true,
       perms: [Perms.READ]
     });
     this.value = this.getDefaultValue();
@@ -2119,6 +2123,7 @@ export class SerialNumber extends Characteristic {
     super('Serial Number', SerialNumber.UUID);
     this.setProps({
       format: Formats.STRING,
+      configUpdate: true,
       perms: [Perms.READ]
     });
     this.value = this.getDefaultValue();


### PR DESCRIPTION
While I was working on the issue https://github.com/NRCHKB/node-red-contrib-homekit-bridged/issues/12 I noticed that the clients don't get informed about changes of some core characteristics (e.g. Name, Firmware Revision, Model, ...). To inform the clients about those kind of changes the configuration version (TXT Record key "c#") needs to be increased to tell the clients that the configuration has changed.

To automatically update the configuration after specific characteristics changed I defined a new property for characteristics. Every time a characteristic gets changed which has this property set to true the configuration will automatically be updated. This property defaults to false and can be overwritten in the characteristic definition.