### PR TITLE
Corrected returned error codes in /pair-setup and improved session security.

### DIFF
--- a/src/lib/util/encryption.ts
+++ b/src/lib/util/encryption.ts
@@ -95,7 +95,7 @@ export function layerDecrypt(packet: Buffer, count: Count, key: Buffer, extraInf
       } else {
         debug('Layer Decrypt fail!');
         debug('Packet: %s', packet.toString('hex'));
-        return 0;
+        throw new Error("Layer verification failed!");
       }
   }
 

--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -24,7 +24,7 @@ export enum EventedHTTPServerEvents {
 export type Events = {
   [EventedHTTPServerEvents.LISTENING]: (port: number) => void;
   [EventedHTTPServerEvents.REQUEST]: (request: IncomingMessage, response: ServerResponse, session: Session, events: any) => void;
-  [EventedHTTPServerEvents.DECRYPT]: (data: Buffer, decrypted: { data: Buffer; }, session: Session) => void;
+  [EventedHTTPServerEvents.DECRYPT]: (data: Buffer, decrypted: { data: Buffer; error: Error | null }, session: Session) => void;
   [EventedHTTPServerEvents.ENCRYPT]: (data: Buffer, encrypted: { data: number | Buffer; }, session: Session) => void;
   [EventedHTTPServerEvents.CLOSE]: (events: any) => void;
   [EventedHTTPServerEvents.SESSION_CLOSE]: (sessionID: string, events: any) => void;
@@ -389,16 +389,25 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
   // Received data from client (iOS)
   _onClientSocketData = (data: Buffer) => {
     // give listeners an opportunity to decrypt this data before processing it as HTTP
-    var decrypted = {data: null};
+    var decrypted: {data: Buffer | null, error: Error | null} = {data: null, error: null};
     this.emit(EventedHTTPServerEvents.DECRYPT, data, decrypted, this._session);
-    if (decrypted.data)
-      data = decrypted.data as unknown as Buffer;
-    if (this._fullySetup) {
-      // proxy it along to the HTTP server
-      this._serverSocket && this._serverSocket.write(data);
+
+    if (decrypted.error) {
+      // decryption and/or verification failed, disconnect the client
+      debug("[%s] Error occurred trying to decrypt incoming packet: %s", this._remoteAddress, decrypted.error.message);
+      this.close();
     } else {
-      // we're not setup yet, so add this data to our buffer
-      this._pendingClientSocketData = Buffer.concat([this._pendingClientSocketData!, data]);
+      if (decrypted.data) {
+        data = decrypted.data;
+      }
+
+      if (this._fullySetup) {
+        // proxy it along to the HTTP server
+        this._serverSocket && this._serverSocket.write(data);
+      } else {
+        // we're not setup yet, so add this data to our buffer
+        this._pendingClientSocketData = Buffer.concat([this._pendingClientSocketData!, data]);
+      }
     }
   }
 


### PR DESCRIPTION
This PR ensures that the correct error codes are returned when a /pair-setup fails.
Additionally message authentication is now enforced for secured sessions.