### PR TITLE
Resolve TypeScript Typings and Engine Version Conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -469,9 +469,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
+      "version": "10.17.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+      "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=4.3.2"
+    "node": ">=10.17.0"
   },
   "dependencies": {
     "bonjour-hap": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/debug": "^4.1.4",
     "@types/ip": "^1.1.0",
     "@types/jest": "^24.0.15",
-    "@types/node": "^12.6.8",
+    "@types/node": "^10.17.13",
     "jest": "^24.8.0",
     "rimraf": "^2.7.1",
     "simple-plist": "0.0.4",

--- a/src/accessories/gstreamer-audioProducer.ts
+++ b/src/accessories/gstreamer-audioProducer.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import createDebug from 'debug';
-import {ChildProcessWithoutNullStreams, spawn} from 'child_process';
+import {ChildProcess, spawn} from 'child_process';
 import {AudioCodecConfiguration, ErrorHandler, FrameHandler, SiriAudioStreamProducer} from "../lib/HomeKitRemoteController";
 import {AudioCodecParamBitRateTypes, AudioCodecParamSampleRateTypes, AudioCodecTypes} from "../lib/StreamController";
 import {DataSendCloseReason} from "../index";
@@ -49,7 +49,7 @@ export class GStreamerAudioProducer implements SiriAudioStreamProducer {
     private readonly frameHandler: FrameHandler;
     private readonly errorHandler: ErrorHandler;
 
-    private process?: ChildProcessWithoutNullStreams;
+    private process?: ChildProcess;
     private running: boolean = false;
 
     constructor(frameHandler: FrameHandler, errorHandler: ErrorHandler, options?: Partial<GStreamerOptions>) {

--- a/src/lib/Camera.ts
+++ b/src/lib/Camera.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import ip from 'ip';
-import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import { ChildProcess, spawn } from 'child_process';
 
 import { Service } from './Service';
 import {
@@ -34,7 +34,7 @@ export class Camera {
   services: Service[] = [];
   streamControllers: StreamController[] = [];
   pendingSessions: Record<string, SessionInfo> = {};
-  ongoingSessions: Record<string, ChildProcessWithoutNullStreams> = {};
+  ongoingSessions: Record<string, ChildProcess> = {};
 
   constructor() {
 

--- a/src/lib/datastream/DataStreamParser.ts
+++ b/src/lib/datastream/DataStreamParser.ts
@@ -759,7 +759,7 @@ export class DataStreamWriter {
         const byteLength = Buffer.byteLength(utf8);
         this.ensureLength(byteLength);
 
-        this.data.write(utf8, this.writerIndex, "utf8");
+        this.data.write(utf8, this.writerIndex, undefined, "utf8");
         this.writerIndex += byteLength;
     }
 

--- a/src/lib/util/hkdf.ts
+++ b/src/lib/util/hkdf.ts
@@ -1,5 +1,6 @@
-import crypto, { BinaryLike } from 'crypto';
+import crypto from 'crypto';
 import bufferShim from 'buffer-shims';
+import { BinaryLike } from './uuid';
 
 export function HKDF(hashAlg: string, salt: BinaryLike, ikm: BinaryLike, info: Buffer, size: number) {
   // create the hash alg to see if it exists and get its length

--- a/src/lib/util/uuid.ts
+++ b/src/lib/util/uuid.ts
@@ -1,4 +1,7 @@
-import crypto, { BinaryLike } from 'crypto';
+import crypto from 'crypto';
+
+type Binary = Buffer | NodeJS.TypedArray | DataView;
+export type BinaryLike = string | Binary;
 
 // http://stackoverflow.com/a/25951500/66673
 export function generate(data: BinaryLike) {
@@ -42,6 +45,6 @@ export function write(uuid: string, buf: Buffer, offset: number = 0) {
 
   for (let i = 0; i < uuid.length; i += 2) {
     const octet = uuid.substring(i, i + 2);
-    buf.write(octet, offset++, "hex");
+    buf.write(octet, offset++, undefined, "hex");
   }
 }


### PR DESCRIPTION
This pull request implements the [proposed changes](https://github.com/KhaosT/HAP-NodeJS/issues/761#issuecomment-574480153) in issue #676 

1. Moves the Node engine support from v4 to v10 (48196df03a9f6d7c1d15614c457e7107d454621c).
2. Downgrades the Node `@types/node` from v12 to v10. This makes type type definitions match the major version and minor version tagged in the semver string of the Node's version (f07d4e98c34957021d46e3605759dcf977b42faf).

There are a few knock on effects from downgrading the `@types/node` from v12 to v10. Specifically, there were new build errors introduced (expand below for those errors fixed in f07d4e98c34957021d46e3605759dcf977b42faf).

<details><summary>Expand: Example build errors fixed by f07d4e98c34957021d46e3605759dcf977b42faf</summary>
<p>

```text
$ npm run build

> hap-nodejs@0.5.5 build /Users/rlovelett/Source/HAP-NodeJS
> rimraf dist/ && tsc

src/accessories/gstreamer-audioProducer.ts:3:9 - error TS2305: Module '"child_process"' has no exported member 'ChildProcessWithoutNullStreams'.

3 import {ChildProcessWithoutNullStreams, spawn} from 'child_process';
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/accessories/gstreamer-audioProducer.ts:114:34 - error TS7006: Parameter 'error' implicitly has an 'any' type.

114         this.process.on("error", error => {
                                     ~~~~~

src/accessories/gstreamer-audioProducer.ts:143:40 - error TS7006: Parameter 'data' implicitly has an 'any' type.

143         this.process.stderr.on("data", data => {
                                           ~~~~

src/accessories/gstreamer-audioProducer.ts:146:34 - error TS7006: Parameter 'code' implicitly has an 'any' type.

146         this.process.on("exit", (code, signal) => {
                                     ~~~~

src/accessories/gstreamer-audioProducer.ts:146:40 - error TS7006: Parameter 'signal' implicitly has an 'any' type.

146         this.process.on("exit", (code, signal) => {
                                           ~~~~~~

src/lib/Camera.ts:4:10 - error TS2305: Module '"child_process"' has no exported member 'ChildProcessWithoutNullStreams'.

4 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/lib/datastream/DataStreamParser.ts:762:49 - error TS2345: Argument of type '"utf8"' is not assignable to parameter of type 'number | undefined'.

762         this.data.write(utf8, this.writerIndex, "utf8");
                                                    ~~~~~~

src/lib/util/hkdf.ts:1:18 - error TS2305: Module '"crypto"' has no exported member 'BinaryLike'.

1 import crypto, { BinaryLike } from 'crypto';
                   ~~~~~~~~~~

src/lib/util/uuid.ts:1:18 - error TS2305: Module '"crypto"' has no exported member 'BinaryLike'.

1 import crypto, { BinaryLike } from 'crypto';
                   ~~~~~~~~~~

src/lib/util/uuid.ts:45:32 - error TS2345: Argument of type '"hex"' is not assignable to parameter of type 'number | undefined'.

45     buf.write(octet, offset++, "hex");
                                  ~~~~~


Found 10 errors.
```

</p>
</details>


Resolves issue #761.

#### Note

I'm reasonably sure there is a failing test on master. I do not believe it is related to this pull-request.

<details><summary>Expand: Failing test on master</summary>
<p>

```text
  ● Test suite failed to run

    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    src/lib/Advertiser.spec.ts:6:25 - error TS2673: Constructor of class 'AccessoryInfo' is private and only accessible within the class declaration.

    6   return new Advertiser(new AccessoryInfo('displayName'), {
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
</p>
</details>