### PR TITLE
Remove obsolete dependency of buffer-shims

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -921,11 +921,6 @@
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "bonjour-hap": "^3.5.1",
-    "buffer-shims": "^1.0.0",
     "debug": "^2.2.0",
     "decimal.js": "^7.2.3",
     "fast-srp-hap": "^1.0.1",

--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -1,4 +1,3 @@
-import bufferShim from 'buffer-shims';
 import crypto from 'crypto';
 import createDebug from 'debug';
 
@@ -478,7 +477,7 @@ export class Accessory extends EventEmitter<Events> {
       return this._setupURI;
     }
 
-    var buffer = bufferShim.alloc(8);
+    var buffer = Buffer.alloc(8);
     var setupCode = this._accessoryInfo && parseInt(this._accessoryInfo.pincode.replace(/-/g, ''), 10);
 
     var value_low = setupCode!;

--- a/src/lib/Characteristic.ts
+++ b/src/lib/Characteristic.ts
@@ -1,5 +1,4 @@
 import Decimal from 'decimal.js';
-import bufferShim from 'buffer-shims';
 
 import { once } from './util/once';
 import { IdentifierCache } from './model/IdentifierCache';
@@ -722,7 +721,7 @@ export class Characteristic extends EventEmitter<Events> {
       hap.minStep = this.props.minStep;
     // add maxLen if string length is > 64 bytes and trim to max 256 bytes
     if (this.props.format === Formats.STRING) {
-      var str = bufferShim.from(value as string, 'utf8'), len = str.byteLength;
+      var str = Buffer.from(value as string, 'utf8'), len = str.byteLength;
       if (len > 256) { // 256 bytes is the max allowed length
         hap.value = str.toString('utf8', 0, 256);
         hap.maxLen = 256;

--- a/src/lib/HAPServer.ts
+++ b/src/lib/HAPServer.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 
-import bufferShim from 'buffer-shims';
 import createDebug from 'debug';
 import srp from 'fast-srp-hap';
 import tweetnacl from 'tweetnacl';
@@ -304,7 +303,7 @@ export class HAPServer extends EventEmitter<Events> {
   _onRequest = (request: IncomingMessage, response: ServerResponse, session: Session, events: any) => {
     debug("[%s] HAP Request: %s %s", this.accessoryInfo.username, request.method, request.url);
     // collect request data, if any
-    var requestData = bufferShim.alloc(0);
+    var requestData = Buffer.alloc(0);
     request.on('data', (data) => {
       requestData = Buffer.concat([requestData, data]);
     });
@@ -428,7 +427,7 @@ export class HAPServer extends EventEmitter<Events> {
     var srpParams = srp.params["3072"];
     srp.genKey(32, (error: Error, key: Buffer) => {
       // create a new SRP server
-      var srpServer = new srp.Server(srpParams, bufferShim.from(salt), bufferShim.from("Pair-Setup"), bufferShim.from(this.accessoryInfo.pincode), key);
+      var srpServer = new srp.Server(srpParams, Buffer.from(salt), Buffer.from("Pair-Setup"), Buffer.from(this.accessoryInfo.pincode), key);
       var srpB = srpServer.computeB();
       // attach it to the current TCP session
       session.srpServer = srpServer;
@@ -469,16 +468,16 @@ export class HAPServer extends EventEmitter<Events> {
     // pull the SRP server we created in stepOne out of the current session
     var srpServer = session.srpServer!;
     var encryptedData = objects[TLVValues.ENCRYPTED_DATA];
-    var messageData = bufferShim.alloc(encryptedData.length - 16);
-    var authTagData = bufferShim.alloc(16);
+    var messageData = Buffer.alloc(encryptedData.length - 16);
+    var authTagData = Buffer.alloc(16);
     encryptedData.copy(messageData, 0, 0, encryptedData.length - 16);
     encryptedData.copy(authTagData, 0, encryptedData.length - 16, encryptedData.length);
     var S_private = srpServer.computeK();
-    var encSalt = bufferShim.from("Pair-Setup-Encrypt-Salt");
-    var encInfo = bufferShim.from("Pair-Setup-Encrypt-Info");
+    var encSalt = Buffer.from("Pair-Setup-Encrypt-Salt");
+    var encInfo = Buffer.from("Pair-Setup-Encrypt-Info");
     var outputKey = hkdf.HKDF("sha512", encSalt, S_private, encInfo, 32);
-    var plaintextBuffer = bufferShim.alloc(messageData.length);
-    if (!encryption.verifyAndDecrypt(outputKey, bufferShim.from("PS-Msg05"), messageData, authTagData, null, plaintextBuffer)) {
+    var plaintextBuffer = Buffer.alloc(messageData.length);
+    if (!encryption.verifyAndDecrypt(outputKey, Buffer.from("PS-Msg05"), messageData, authTagData, null, plaintextBuffer)) {
       debug("[%s] Error while decrypting and verifying M5 subTlv: %s", this.accessoryInfo.username);
       response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
       response.end(tlv.encode(TLVValues.SEQUENCE_NUM, States.M4, TLVValues.ERROR_CODE, Codes.AUTHENTICATION));
@@ -498,8 +497,8 @@ export class HAPServer extends EventEmitter<Events> {
   _handlePairStepFour = (request: IncomingMessage, response: ServerResponse, session: Session, clientUsername: Buffer, clientLTPK: Buffer, clientProof: Buffer, hkdfEncKey: Buffer) => {
     debug("[%s] Pair step 4/5", this.accessoryInfo.username);
     var S_private = session.srpServer!.computeK();
-    var controllerSalt = bufferShim.from("Pair-Setup-Controller-Sign-Salt");
-    var controllerInfo = bufferShim.from("Pair-Setup-Controller-Sign-Info");
+    var controllerSalt = Buffer.from("Pair-Setup-Controller-Sign-Salt");
+    var controllerInfo = Buffer.from("Pair-Setup-Controller-Sign-Info");
     var outputKey = hkdf.HKDF("sha512", controllerSalt, S_private, controllerInfo, 32);
     var completeData = Buffer.concat([outputKey, clientUsername, clientLTPK]);
     if (!tweetnacl.sign.detached.verify(completeData, clientProof, clientLTPK)) {
@@ -516,18 +515,18 @@ export class HAPServer extends EventEmitter<Events> {
   _handlePairStepFive = (request: IncomingMessage, response: ServerResponse, session: Session, clientUsername: Buffer, clientLTPK: Buffer, hkdfEncKey: Buffer) => {
     debug("[%s] Pair step 5/5", this.accessoryInfo.username);
     var S_private = session.srpServer!.computeK();
-    var accessorySalt = bufferShim.from("Pair-Setup-Accessory-Sign-Salt");
-    var accessoryInfo = bufferShim.from("Pair-Setup-Accessory-Sign-Info");
+    var accessorySalt = Buffer.from("Pair-Setup-Accessory-Sign-Salt");
+    var accessoryInfo = Buffer.from("Pair-Setup-Accessory-Sign-Info");
     var outputKey = hkdf.HKDF("sha512", accessorySalt, S_private, accessoryInfo, 32);
     var serverLTPK = this.accessoryInfo.signPk;
-    var usernameData = bufferShim.from(this.accessoryInfo.username);
+    var usernameData = Buffer.from(this.accessoryInfo.username);
     var material = Buffer.concat([outputKey, usernameData, serverLTPK]);
-    var privateKey = bufferShim.from(this.accessoryInfo.signSk);
+    var privateKey = Buffer.from(this.accessoryInfo.signSk);
     var serverProof = tweetnacl.sign.detached(material, privateKey);
     var message = tlv.encode(TLVValues.USERNAME, usernameData, TLVValues.PUBLIC_KEY, serverLTPK, TLVValues.PROOF, serverProof);
-    var ciphertextBuffer = bufferShim.alloc(message.length);
-    var macBuffer = bufferShim.alloc(16);
-    encryption.encryptAndSeal(hkdfEncKey, bufferShim.from("PS-Msg06"), message, null, ciphertextBuffer, macBuffer);
+    var ciphertextBuffer = Buffer.alloc(message.length);
+    var macBuffer = Buffer.alloc(16);
+    encryption.encryptAndSeal(hkdfEncKey, Buffer.from("PS-Msg06"), message, null, ciphertextBuffer, macBuffer);
     // finally, notify listeners that we have been paired with a client
     this.emit(HAPServerEventTypes.PAIR, clientUsername.toString(), clientLTPK, once((err?: Error) => {
       if (err) {
@@ -567,15 +566,15 @@ export class HAPServer extends EventEmitter<Events> {
     var clientPublicKey = objects[TLVValues.PUBLIC_KEY]; // Buffer
     // generate new encryption keys for this session
     var keyPair = encryption.generateCurve25519KeyPair();
-    var secretKey = bufferShim.from(keyPair.secretKey);
-    var publicKey = bufferShim.from(keyPair.publicKey);
-    var sharedSec = bufferShim.from(encryption.generateCurve25519SharedSecKey(secretKey, clientPublicKey));
-    var usernameData = bufferShim.from(this.accessoryInfo.username);
+    var secretKey = Buffer.from(keyPair.secretKey);
+    var publicKey = Buffer.from(keyPair.publicKey);
+    var sharedSec = Buffer.from(encryption.generateCurve25519SharedSecKey(secretKey, clientPublicKey));
+    var usernameData = Buffer.from(this.accessoryInfo.username);
     var material = Buffer.concat([publicKey, usernameData, clientPublicKey]);
-    var privateKey = bufferShim.from(this.accessoryInfo.signSk);
+    var privateKey = Buffer.from(this.accessoryInfo.signSk);
     var serverProof = tweetnacl.sign.detached(material, privateKey);
-    var encSalt = bufferShim.from("Pair-Verify-Encrypt-Salt");
-    var encInfo = bufferShim.from("Pair-Verify-Encrypt-Info");
+    var encSalt = Buffer.from("Pair-Verify-Encrypt-Salt");
+    var encInfo = Buffer.from("Pair-Verify-Encrypt-Info");
     var outputKey = hkdf.HKDF("sha512", encSalt, sharedSec, encInfo, 32).slice(0, 32);
     // store keys in a new instance of HAPEncryption
     var enc = new HAPEncryption();
@@ -589,9 +588,9 @@ export class HAPServer extends EventEmitter<Events> {
     // compose the response data in TLV format
     var message = tlv.encode(TLVValues.USERNAME, usernameData, TLVValues.PROOF, serverProof);
     // encrypt the response
-    var ciphertextBuffer = bufferShim.alloc(message.length);
-    var macBuffer = bufferShim.alloc(16);
-    encryption.encryptAndSeal(outputKey, bufferShim.from("PV-Msg02"), message, null, ciphertextBuffer, macBuffer);
+    var ciphertextBuffer = Buffer.alloc(message.length);
+    var macBuffer = Buffer.alloc(16);
+    encryption.encryptAndSeal(outputKey, Buffer.from("PV-Msg02"), message, null, ciphertextBuffer, macBuffer);
     response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
     response.end(tlv.encode(TLVValues.SEQUENCE_NUM, States.M2, TLVValues.ENCRYPTED_DATA, Buffer.concat([ciphertextBuffer, macBuffer]), TLVValues.PUBLIC_KEY, publicKey));
     session._pairVerifyState = States.M2;
@@ -600,14 +599,14 @@ export class HAPServer extends EventEmitter<Events> {
   _handlePairVerifyStepTwo = (request: IncomingMessage, response: ServerResponse, session: Session, events: any, objects: Record<number, Buffer>) => {
     debug("[%s] Pair verify step 2/2", this.accessoryInfo.username);
     var encryptedData = objects[TLVValues.ENCRYPTED_DATA];
-    var messageData = bufferShim.alloc(encryptedData.length - 16);
-    var authTagData = bufferShim.alloc(16);
+    var messageData = Buffer.alloc(encryptedData.length - 16);
+    var authTagData = Buffer.alloc(16);
     encryptedData.copy(messageData, 0, 0, encryptedData.length - 16);
     encryptedData.copy(authTagData, 0, encryptedData.length - 16, encryptedData.length);
-    var plaintextBuffer = bufferShim.alloc(messageData.length);
+    var plaintextBuffer = Buffer.alloc(messageData.length);
     // instance of HAPEncryption (created in handlePairVerifyStepOne)
     var enc = session.encryption!;
-    if (!encryption.verifyAndDecrypt(enc.hkdfPairEncKey, bufferShim.from("PV-Msg03"), messageData, authTagData, null, plaintextBuffer)) {
+    if (!encryption.verifyAndDecrypt(enc.hkdfPairEncKey, Buffer.from("PV-Msg03"), messageData, authTagData, null, plaintextBuffer)) {
       debug("[%s] M3: Invalid signature", this.accessoryInfo.username);
       response.writeHead(200, {"Content-Type": "application/pairing+tlv8"});
       response.end(tlv.encode(TLVValues.STATE, States.M4, TLVValues.ERROR_CODE, Codes.AUTHENTICATION));
@@ -642,9 +641,9 @@ export class HAPServer extends EventEmitter<Events> {
     // now that the client has been verified, we must "upgrade" our pesudo-HTTP connection to include
     // TCP-level encryption. We'll do this by adding some more encryption vars to the session, and using them
     // in future calls to onEncrypt, onDecrypt.
-    var encSalt = bufferShim.from("Control-Salt");
-    var infoRead = bufferShim.from("Control-Read-Encryption-Key");
-    var infoWrite = bufferShim.from("Control-Write-Encryption-Key");
+    var encSalt = Buffer.from("Control-Salt");
+    var infoRead = Buffer.from("Control-Read-Encryption-Key");
+    var infoWrite = Buffer.from("Control-Write-Encryption-Key");
     enc.accessoryToControllerKey = hkdf.HKDF("sha512", encSalt, enc.sharedSec, infoRead, 32);
     enc.controllerToAccessoryKey = hkdf.HKDF("sha512", encSalt, enc.sharedSec, infoWrite, 32);
     // Our connection is now completely setup. We now want to subscribe this connection to special
@@ -668,15 +667,15 @@ export class HAPServer extends EventEmitter<Events> {
     var clientPublicKey = objects[TLVValues.PUBLIC_KEY]; // Buffer
     // generate new encryption keys for this session
     var keyPair = encryption.generateCurve25519KeyPair();
-    var secretKey = bufferShim.from(keyPair.secretKey);
-    var publicKey = bufferShim.from(keyPair.publicKey);
-    var sharedSec = bufferShim.from(encryption.generateCurve25519SharedSecKey(secretKey, clientPublicKey));
-    var usernameData = bufferShim.from(this.accessoryInfo.username);
+    var secretKey = Buffer.from(keyPair.secretKey);
+    var publicKey = Buffer.from(keyPair.publicKey);
+    var sharedSec = Buffer.from(encryption.generateCurve25519SharedSecKey(secretKey, clientPublicKey));
+    var usernameData = Buffer.from(this.accessoryInfo.username);
     var material = Buffer.concat([publicKey, usernameData, clientPublicKey]);
-    var privateKey = bufferShim.from(this.accessoryInfo.signSk);
+    var privateKey = Buffer.from(this.accessoryInfo.signSk);
     var serverProof = tweetnacl.sign.detached(material, privateKey);
-    var encSalt = bufferShim.from("Pair-Verify-Encrypt-Salt");
-    var encInfo = bufferShim.from("Pair-Verify-Encrypt-Info");
+    var encSalt = Buffer.from("Pair-Verify-Encrypt-Salt");
+    var encInfo = Buffer.from("Pair-Verify-Encrypt-Info");
     var outputKey = hkdf.HKDF("sha512", encSalt, sharedSec, encInfo, 32).slice(0, 32);
     // store keys in a new instance of HAPEncryption
     var enc = new HAPEncryption();
@@ -690,9 +689,9 @@ export class HAPServer extends EventEmitter<Events> {
     // compose the response data in TLV format
     var message = tlv.encode(TLVValues.USERNAME, usernameData, TLVValues.PROOF, serverProof);
     // encrypt the response
-    var ciphertextBuffer = bufferShim.alloc(message.length);
-    var macBuffer = bufferShim.alloc(16);
-    encryption.encryptAndSeal(outputKey, bufferShim.from("PV-Msg02"), message, null, ciphertextBuffer, macBuffer);
+    var ciphertextBuffer = Buffer.alloc(message.length);
+    var macBuffer = Buffer.alloc(16);
+    encryption.encryptAndSeal(outputKey, Buffer.from("PV-Msg02"), message, null, ciphertextBuffer, macBuffer);
     var response = tlv.encode(TLVValues.SEQUENCE_NUM, 0x02, TLVValues.ENCRYPTED_DATA, Buffer.concat([ciphertextBuffer, macBuffer]), TLVValues.PUBLIC_KEY, publicKey);
     remoteSession.responseMessage(request, response);
   }
@@ -700,14 +699,14 @@ export class HAPServer extends EventEmitter<Events> {
   _handleRemotePairVerifyStepTwo = (request: HapRequest, remoteSession: RemoteSession, session: Session, objects: Record<number, Buffer>) => {
     debug("[%s] Remote Pair verify step 2/2", this.accessoryInfo.username);
     var encryptedData = objects[TLVValues.ENCRYPTED_DATA];
-    var messageData = bufferShim.alloc(encryptedData.length - 16);
-    var authTagData = bufferShim.alloc(16);
+    var messageData = Buffer.alloc(encryptedData.length - 16);
+    var authTagData = Buffer.alloc(16);
     encryptedData.copy(messageData, 0, 0, encryptedData.length - 16);
     encryptedData.copy(authTagData, 0, encryptedData.length - 16, encryptedData.length);
-    var plaintextBuffer = bufferShim.alloc(messageData.length);
+    var plaintextBuffer = Buffer.alloc(messageData.length);
     // instance of HAPEncryption (created in handlePairVerifyStepOne)
     var enc = session.encryption!;
-    if (!encryption.verifyAndDecrypt(enc.hkdfPairEncKey, bufferShim.from("PV-Msg03"), messageData, authTagData, null, plaintextBuffer)) {
+    if (!encryption.verifyAndDecrypt(enc.hkdfPairEncKey, Buffer.from("PV-Msg03"), messageData, authTagData, null, plaintextBuffer)) {
       debug("[%s] M3: Invalid signature", this.accessoryInfo.username);
       var response = tlv.encode(TLVValues.STATE, States.M4, TLVValues.ERROR_CODE, Codes.AUTHENTICATION);
       remoteSession.responseMessage(request, response);
@@ -734,9 +733,9 @@ export class HAPServer extends EventEmitter<Events> {
       return;
     }
     debug("[%s] Client %s verification complete", this.accessoryInfo.username, clientUsername);
-    var encSalt = bufferShim.from("Control-Salt");
-    var infoRead = bufferShim.from("Control-Read-Encryption-Key");
-    var infoWrite = bufferShim.from("Control-Write-Encryption-Key");
+    var encSalt = Buffer.from("Control-Salt");
+    var infoRead = Buffer.from("Control-Read-Encryption-Key");
+    var infoWrite = Buffer.from("Control-Write-Encryption-Key");
     enc.accessoryToControllerKey = hkdf.HKDF("sha512", encSalt, enc.sharedSec, infoRead, 32);
     enc.controllerToAccessoryKey = hkdf.HKDF("sha512", encSalt, enc.sharedSec, infoWrite, 32);
     var response = tlv.encode(TLVValues.SEQUENCE_NUM, 0x04);
@@ -855,7 +854,7 @@ export class HAPServer extends EventEmitter<Events> {
       var response = {
         'configuration-number': this.accessoryInfo.configVersion
       };
-      remoteSession.responseMessage(request, bufferShim.from(JSON.stringify(response)));
+      remoteSession.responseMessage(request, Buffer.from(JSON.stringify(response)));
     } else {
       var self = this;
       // call out to listeners to retrieve the latest accessories JSON
@@ -868,7 +867,7 @@ export class HAPServer extends EventEmitter<Events> {
           'configuration-number': self.accessoryInfo.configVersion,
           'attribute-database': accessories
         };
-        remoteSession.responseMessage(request, bufferShim.from(JSON.stringify(response)));
+        remoteSession.responseMessage(request, Buffer.from(JSON.stringify(response)));
       }));
     }
   }
@@ -1080,7 +1079,7 @@ export class HAPServer extends EventEmitter<Events> {
           } as any);
         }
       }
-      remoteSession.responseMessage(request, bufferShim.from(JSON.stringify(characteristics)));
+      remoteSession.responseMessage(request, Buffer.from(JSON.stringify(characteristics)));
     }), true);
   }
 
@@ -1101,7 +1100,7 @@ export class HAPServer extends EventEmitter<Events> {
           } as any);
         }
       }
-      remoteSession.responseMessage(request, bufferShim.from(JSON.stringify(characteristics)));
+      remoteSession.responseMessage(request, Buffer.from(JSON.stringify(characteristics)));
     }, true);
   }
 }
@@ -1126,15 +1125,15 @@ export class HAPEncryption {
 
   constructor() {
     // initialize member vars with null-object values
-    this.clientPublicKey = bufferShim.alloc(0);
-    this.secretKey = bufferShim.alloc(0);
-    this.publicKey = bufferShim.alloc(0);
-    this.sharedSec = bufferShim.alloc(0);
-    this.hkdfPairEncKey = bufferShim.alloc(0);
+    this.clientPublicKey = Buffer.alloc(0);
+    this.secretKey = Buffer.alloc(0);
+    this.publicKey = Buffer.alloc(0);
+    this.sharedSec = Buffer.alloc(0);
+    this.hkdfPairEncKey = Buffer.alloc(0);
     this.accessoryToControllerCount = { value: 0 };
     this.controllerToAccessoryCount = { value: 0 };
-    this.accessoryToControllerKey = bufferShim.alloc(0);
-    this.controllerToAccessoryKey = bufferShim.alloc(0);
+    this.accessoryToControllerKey = Buffer.alloc(0);
+    this.controllerToAccessoryKey = Buffer.alloc(0);
     this.extraInfo = {};
   }
 }

--- a/src/lib/HomeKitRemoteController.ts
+++ b/src/lib/HomeKitRemoteController.ts
@@ -1,5 +1,4 @@
 import * as tlv from './util/tlv';
-import bufferShim from "buffer-shims";
 import createDebug from 'debug';
 import assert from 'assert';
 
@@ -548,7 +547,7 @@ export class HomeKitRemoteController extends EventEmitter<RemoteControllerEventM
     // --------------------------------- TARGET CONTROL ----------------------------------
 
     private handleTargetControlWrite = (value: any, callback: CharacteristicSetCallback) => {
-        const data = bufferShim.from(value, 'base64');
+        const data = Buffer.from(value, 'base64');
         const objects = tlv.decode(data);
 
         const operation = objects[TargetControlList.OPERATION][0] as Operation;
@@ -1049,7 +1048,7 @@ export class HomeKitRemoteController extends EventEmitter<RemoteControllerEventM
     // ------------------------------- AUDIO CONFIGURATION -------------------------------
 
     private handleSelectedAudioConfigurationWrite = (value: any, callback: CharacteristicSetCallback) => {
-        const data = bufferShim.from(value, 'base64');
+        const data = Buffer.from(value, 'base64');
         const objects = tlv.decode(data);
 
         const selectedAudioStreamConfiguration = tlv.decode(

--- a/src/lib/StreamController.ts
+++ b/src/lib/StreamController.ts
@@ -1,7 +1,6 @@
 import crypto from 'crypto';
 
 import ip from 'ip';
-import bufferShim from 'buffer-shims';
 import createDebug from 'debug';
 
 import * as tlv from './util/tlv';
@@ -399,7 +398,7 @@ export class StreamController {
   _handleSelectedStreamConfigurationWrite = (value: any, callback: any, connectionID: string) => {
     this.selectedConfiguration = value;
 
-    var data = bufferShim.from(value, 'base64');
+    var data = Buffer.from(value, 'base64');
     var objects = tlv.decode(data);
 
     var session;
@@ -590,7 +589,7 @@ export class StreamController {
 
   _handleSetupWrite = (value: CharacteristicValue, callback: HandleSetupWriteCallback) => {
 
-    var data = bufferShim.from(`${value}`, 'base64');
+    var data = Buffer.from(`${value}`, 'base64');
     var objects = tlv.decode(data) as any;
 
     this.sessionIdentifier = objects[SetupTypes.SESSION_ID];
@@ -711,14 +710,14 @@ export class StreamController {
 
     let ipVer = 0;
     let ipAddress = null;
-    const videoPort = bufferShim.alloc(2);
-    const audioPort = bufferShim.alloc(2);
+    const videoPort = Buffer.alloc(2);
+    const audioPort = Buffer.alloc(2);
 
-    const videoSSRC = bufferShim.alloc(4);
-    const audioSSRC = bufferShim.alloc(4);
+    const videoSSRC = Buffer.alloc(4);
+    const audioSSRC = Buffer.alloc(4);
 
-    let videoSRTP = bufferShim.from([0x01, 0x01, 0x02, 0x02, 0x00, 0x03, 0x00]);
-    let audioSRTP = bufferShim.from([0x01, 0x01, 0x02, 0x02, 0x00, 0x03, 0x00]);
+    let videoSRTP = Buffer.from([0x01, 0x01, 0x02, 0x02, 0x00, 0x03, 0x00]);
+    let audioSRTP = Buffer.from([0x01, 0x01, 0x02, 0x02, 0x00, 0x03, 0x00]);
 
     if (this.requireProxy) {
       let currentAddress = ip.address();
@@ -729,7 +728,7 @@ export class StreamController {
         ipVer = 0;
       }
 
-      ipAddress = bufferShim.from(currentAddress);
+      ipAddress = Buffer.from(currentAddress);
       videoPort.writeUInt16LE(this.videoProxy.outgoingLocalPort(), 0);
 
       if (!this.disableAudioProxy) {
@@ -885,17 +884,17 @@ export class StreamController {
       throw new Error('Video resolutions cannot be undefined');
     }
 
-    var videoAttrsTLV = bufferShim.alloc(0);
+    var videoAttrsTLV = Buffer.alloc(0);
     resolutions.forEach(function(resolution) {
       if (resolution.length != 3) {
         throw new Error('Unexpected video resolution');
       }
 
-      var imageWidth = bufferShim.alloc(2);
+      var imageWidth = Buffer.alloc(2);
       imageWidth.writeUInt16LE(resolution[0], 0);
-      var imageHeight = bufferShim.alloc(2);
+      var imageHeight = Buffer.alloc(2);
       imageHeight.writeUInt16LE(resolution[1], 0);
-      var frameRate = bufferShim.alloc(1);
+      var frameRate = Buffer.alloc(1);
       frameRate.writeUInt8(resolution[2], 0);
 
       var videoAttrTLV = tlv.encode(
@@ -932,7 +931,7 @@ export class StreamController {
       throw new Error('Audio codecs cannot be undefined');
     }
 
-    var audioConfigurationsBuffer = bufferShim.alloc(0);
+    var audioConfigurationsBuffer = Buffer.alloc(0);
     var hasSupportedCodec = false;
 
     codecs.forEach(function(codecParam){

--- a/src/lib/datastream/DataStreamManagement.ts
+++ b/src/lib/datastream/DataStreamManagement.ts
@@ -1,5 +1,4 @@
 import * as tlv from '../util/tlv';
-import bufferShim from "buffer-shims";
 import createDebug from "debug";
 import {Service} from "../Service";
 import {
@@ -146,7 +145,7 @@ export class DataStreamManagement {
     }
 
     private handleSetupDataStreamTransportWrite(value: any, callback: CharacteristicSetCallback, connectionID?: string) {
-        const data = bufferShim.from(value, 'base64');
+        const data = Buffer.from(value, 'base64');
         const objects = tlv.decode(data);
 
         const sessionCommandType = objects[SetupDataStreamSessionTypes.SESSION_COMMAND_TYPE][0];

--- a/src/lib/datastream/DataStreamServer.ts
+++ b/src/lib/datastream/DataStreamServer.ts
@@ -1,5 +1,4 @@
 import createDebug from 'debug';
-import bufferShim from "buffer-shims";
 import assert from 'assert';
 
 import * as encryption from '../util/encryption';
@@ -149,8 +148,8 @@ export class DataStreamServer extends EventEmitter<DataStreamServerEventMap> {
 
     private state: ServerState = ServerState.UNINITIALIZED;
 
-    private static accessoryToControllerInfo = bufferShim.from("HDS-Read-Encryption-Key");
-    private static controllerToAccessoryInfo = bufferShim.from("HDS-Write-Encryption-Key");
+    private static accessoryToControllerInfo = Buffer.from("HDS-Read-Encryption-Key");
+    private static controllerToAccessoryInfo = Buffer.from("HDS-Write-Encryption-Key");
 
     private tcpServer?: net.Server;
     private tcpPort?: number;
@@ -753,7 +752,7 @@ export class DataStreamConnection extends EventEmitter<DataStreamConnectionEvent
 
             const header = data.slice(frameBegin, payloadBegin); // header is also authenticated using authTag
             const cipheredPayload = data.slice(payloadBegin, authTagBegin);
-            const plaintextPayload = bufferShim.alloc(payloadLength);
+            const plaintextPayload = Buffer.alloc(payloadLength);
             const authTag = data.slice(authTagBegin, authTagBegin + 16);
 
             frameBegin = authTagBegin + 16; // move to next frame

--- a/src/lib/model/AccessoryInfo.ts
+++ b/src/lib/model/AccessoryInfo.ts
@@ -2,7 +2,6 @@ import storage from 'node-persist';
 import util from 'util';
 import assert from 'assert';
 import tweetnacl from 'tweetnacl';
-import bufferShim from 'buffer-shims';
 
 import { Categories } from '../Accessory';
 import { Session } from "../util/eventedhttp";
@@ -50,8 +49,8 @@ export class AccessoryInfo {
     // @ts-ignore
     this.category = "";
     this.pincode = "";
-    this.signSk = bufferShim.alloc(0);
-    this.signPk = bufferShim.alloc(0);
+    this.signSk = Buffer.alloc(0);
+    this.signPk = Buffer.alloc(0);
     this.pairedClients = {};
     this.pairedAdminClients = 0;
     this.configVersion = 1;
@@ -242,8 +241,8 @@ export class AccessoryInfo {
     // Create a new unique key pair for this accessory.
     var keyPair = tweetnacl.sign.keyPair();
 
-    accessoryInfo.signSk = bufferShim.from(keyPair.secretKey);
-    accessoryInfo.signPk = bufferShim.from(keyPair.publicKey);
+    accessoryInfo.signSk = Buffer.from(keyPair.secretKey);
+    accessoryInfo.signPk = Buffer.from(keyPair.publicKey);
 
     return accessoryInfo;
   }
@@ -259,8 +258,8 @@ export class AccessoryInfo {
       info.displayName = saved.displayName || "";
       info.category = saved.category || "";
       info.pincode = saved.pincode || "";
-      info.signSk = bufferShim.from(saved.signSk || '', 'hex');
-      info.signPk = bufferShim.from(saved.signPk || '', 'hex');
+      info.signSk = Buffer.from(saved.signSk || '', 'hex');
+      info.signPk = Buffer.from(saved.signPk || '', 'hex');
 
       info.pairedClients = {};
       for (var username in saved.pairedClients || {}) {
@@ -271,7 +270,7 @@ export class AccessoryInfo {
 
         info.pairedClients[username] = {
           username: username,
-          publicKey: bufferShim.from(publicKey, 'hex'),
+          publicKey: Buffer.from(publicKey, 'hex'),
           permission: permission
         };
         if (permission === PermissionTypes.ADMIN)

--- a/src/lib/util/chacha20poly1305.ts
+++ b/src/lib/util/chacha20poly1305.ts
@@ -5,8 +5,6 @@
 // Implementation derived from chacha-ref.c version 20080118
 // See for details: http://cr.yp.to/chacha/chacha-20080128.pdf
 
-import bufferShim from 'buffer-shims';
-
 var Chacha20KeySize   = 32;
 var Chacha20NonceSize =  8;
 
@@ -18,7 +16,7 @@ export class Chacha20Ctx {
   constructor() {
     this.input = new Array(16);
     this.leftover = 0;
-    this.buffer = bufferShim.alloc(64);
+    this.buffer = Buffer.alloc(64);
   }
 }
 
@@ -145,7 +143,7 @@ export function chacha20_update(ctx: Chacha20Ctx, dst: Buffer, src: Buffer, inle
         if (src.length > 0) {
             src.copy(ctx.buffer,ctx.leftover,0,src.length);
         } else {
-            var zeros = bufferShim.alloc(inlen);
+            var zeros = Buffer.alloc(inlen);
             zeros.copy(ctx.buffer,ctx.leftover,0,inlen);
         }
         ctx.leftover += inlen;

--- a/src/lib/util/eventedhttp.ts
+++ b/src/lib/util/eventedhttp.ts
@@ -2,7 +2,6 @@ import net, { AddressInfo, Socket } from 'net';
 import http, { IncomingMessage, OutgoingMessage, ServerResponse } from 'http';
 
 import createDebug from 'debug';
-import bufferShim from 'buffer-shims';
 import srp from 'fast-srp-hap';
 
 import * as uuid from './uuid';
@@ -278,7 +277,7 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     this.server = server;
     this.sessionID = uuid.generate(clientSocket.remoteAddress + ':' + clientSocket.remotePort);
     this._remoteAddress = clientSocket.remoteAddress!; // cache because it becomes undefined in 'onClientSocketClose'
-    this._pendingClientSocketData = bufferShim.alloc(0); // data received from client before HTTP proxy is fully setup
+    this._pendingClientSocketData = Buffer.alloc(0); // data received from client before HTTP proxy is fully setup
     this._fullySetup = false; // true when we are finished establishing connections
     this._writingResponse = false; // true while we are composing an HTTP response (so events can wait)
     this._killSocketAfterWrite = false;
@@ -318,14 +317,14 @@ class EventedHTTPServerConnection extends EventEmitter<Events> {
     debug("[%s] Sending HTTP event '%s' with data: %s", this._remoteAddress, event, data.toString('utf8'));
     // ensure data is a Buffer
     if (typeof data === 'string') {
-      data = bufferShim.from(data);
+      data = Buffer.from(data);
     }
     // format this payload as an HTTP response
-    var linebreak = bufferShim.from("0D0A", "hex");
+    var linebreak = Buffer.from("0D0A", "hex");
     data = Buffer.concat([
-      bufferShim.from('EVENT/1.0 200 OK'), linebreak,
-      bufferShim.from('Content-Type: ' + contentType), linebreak,
-      bufferShim.from('Content-Length: ' + data.length), linebreak,
+      Buffer.from('EVENT/1.0 200 OK'), linebreak,
+      Buffer.from('Content-Type: ' + contentType), linebreak,
+      Buffer.from('Content-Length: ' + data.length), linebreak,
       linebreak,
       data
     ]);

--- a/src/lib/util/hkdf.ts
+++ b/src/lib/util/hkdf.ts
@@ -1,5 +1,4 @@
 import crypto from 'crypto';
-import bufferShim from 'buffer-shims';
 import { BinaryLike } from './uuid';
 
 export function HKDF(hashAlg: string, salt: BinaryLike, ikm: BinaryLike, info: Buffer, size: number) {
@@ -14,10 +13,10 @@ export function HKDF(hashAlg: string, salt: BinaryLike, ikm: BinaryLike, info: B
 
   const buffers = [];
   const num_blocks = Math.ceil(size / hashLength);
-  let prev = bufferShim.alloc(0);
+  let prev = Buffer.alloc(0);
   let output;
 
-  info = bufferShim.from(info);
+  info = Buffer.from(info);
 
   for (var i=0; i<num_blocks; i++) {
     var blockHmac = crypto.createHmac(hashAlg, prk);
@@ -25,7 +24,7 @@ export function HKDF(hashAlg: string, salt: BinaryLike, ikm: BinaryLike, info: B
     var input = Buffer.concat([
       prev,
       info,
-      bufferShim.from(String.fromCharCode(i + 1))
+      Buffer.from(String.fromCharCode(i + 1))
     ]);
     blockHmac.update(input);
     prev = blockHmac.digest();

--- a/src/lib/util/tlv.ts
+++ b/src/lib/util/tlv.ts
@@ -1,5 +1,3 @@
-import bufferShim from 'buffer-shims';
-
 /**
  * Type Length Value encoding/decoding, used by HAP as a wire format.
  * https://en.wikipedia.org/wiki/Type-length-value
@@ -7,28 +5,28 @@ import bufferShim from 'buffer-shims';
 
 export function encode(type: number, data: Buffer | number | string, ...args: any[]) {
 
-    var encodedTLVBuffer = bufferShim.alloc(0);
+    var encodedTLVBuffer = Buffer.alloc(0);
 
     // coerce data to Buffer if needed
     if (typeof data === 'number')
-      data = bufferShim.from([data]) as Buffer;
+      data = Buffer.from([data]) as Buffer;
     else if (typeof data === 'string')
-      data = bufferShim.from(data) as Buffer;
+      data = Buffer.from(data) as Buffer;
 
     if (data.length <= 255) {
-        encodedTLVBuffer = Buffer.concat([bufferShim.from([type,data.length]),data]);
+        encodedTLVBuffer = Buffer.concat([Buffer.from([type,data.length]),data]);
     } else {
         var leftLength = data.length;
-        var tempBuffer = bufferShim.alloc(0);
+        var tempBuffer = Buffer.alloc(0);
         var currentStart = 0;
 
         for (; leftLength > 0;) {
             if (leftLength >= 255) {
-                tempBuffer = Buffer.concat([tempBuffer,bufferShim.from([type,0xFF]),data.slice(currentStart, currentStart + 255)]);
+                tempBuffer = Buffer.concat([tempBuffer,Buffer.from([type,0xFF]),data.slice(currentStart, currentStart + 255)]);
                 leftLength -= 255;
                 currentStart = currentStart + 255;
             } else {
-                tempBuffer = Buffer.concat([tempBuffer,bufferShim.from([type,leftLength]),data.slice(currentStart, currentStart + leftLength)]);
+                tempBuffer = Buffer.concat([tempBuffer,Buffer.from([type,leftLength]),data.slice(currentStart, currentStart + leftLength)]);
                 leftLength -= leftLength;
             }
         }
@@ -137,7 +135,7 @@ export function readUInt64(buffer: Buffer) {
 }
 
 export function writeUInt32(value: number) {
-    const buffer = bufferShim.alloc(4);
+    const buffer = Buffer.alloc(4);
 
     buffer.writeUInt32LE(value, 0);
 
@@ -149,7 +147,7 @@ export function readUInt32(buffer: Buffer) {
 }
 
 export function writeUInt16(value: number) {
-    const buffer = bufferShim.alloc(2);
+    const buffer = Buffer.alloc(2);
 
     buffer.writeUInt16LE(value, 0);
 

--- a/src/types/buffer-shims.d.ts
+++ b/src/types/buffer-shims.d.ts
@@ -1,5 +1,0 @@
-declare module 'buffer-shims' {
-
-  const B: typeof Buffer;
-  export = B;
-}


### PR DESCRIPTION
This PR removes the dependency of `buffer-shims` as node v4 support was dropped.