### PR TITLE
Adding configuration for GitHub actions CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,27 @@
+name: Node CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 13.x]
+        os: [ubuntu-latest, macOS-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install, build and test
+        run: |
+          npm ci
+          npm run build --if-present
+          npm test
+        env:
+          CI: true

--- a/src/lib/Advertiser.spec.ts
+++ b/src/lib/Advertiser.spec.ts
@@ -3,7 +3,7 @@ import { AccessoryInfo } from './model/AccessoryInfo';
 import './gen';
 
 const createAdvertiser = () => {
-  return new Advertiser(new AccessoryInfo('displayName'), {
+  return new Advertiser(AccessoryInfo.create('00:00:00:00:00:00'), {
     multicast: false,
     interface: 'ipv6',
     port: 80,


### PR DESCRIPTION
This PR is a proposal to add a CI runner to the project.
There is no real benefit, if we have some unit tests but never run them and regressions potential get published unnoticed.

Additionally I fixed an already broken Tests in this PR.

I don't really care what CI runner we are going to use, I just picked Travis, since the integration with GitHub seems pretty good and it worked for me in the past.
Additionally you could hook up travis to [deploy npm releases](https://docs.travis-ci.com/user/deployment/npm/) (a new version is published for every tagged commit). For me this feature wasn't always reliable, but in every case you would need to finish the setup @KhaosT (setup travis for your account and maybe add deployment tokens).