### PR TITLE
Adding Badges for NPM, NPM Downloads, Build Node CI, Issues, and Pull…

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: Node-CI
 
 on: [push, pull_request]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 HAP-NodeJS
 ==========
+[![npm](https://img.shields.io/npm/v/hap-nodejs?style=for-the-badge)](https://www.npmjs.com/package/hap-nodejs)
+[![npm](https://img.shields.io/npm/dt/hap-nodejs?style=for-the-badge)](https://www.npmjs.com/package/hap-nodejs)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ KhaosT/HAP-NodeJS/Node-CI?style=for-the-badge)](https://github.com/KhaosT/HAP-NodeJS/actions?query=workflow%3A%22Node-CI%22)
+[![GitHub issues](https://img.shields.io/github/issues/KhaosT/HAP-NodeJS?style=for-the-badge)](https://github.com/KhaosT/HAP-NodeJS/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/KhaosT/HAP-NodeJS?style=for-the-badge)](https://github.com/KhaosT/HAP-NodeJS/pulls)
 
 [![NPM version](https://badge.fury.io/js/hap-nodejs.svg)](http://badge.fury.io/js/hap-nodejs)
 


### PR DESCRIPTION
… Requests

You will have to rename your Node CI workflow to Node-CI so that it doesn't have a space and so the badge recognizes it.