### PR TITLE
Adding new SmartSpeaker service

### DIFF
--- a/src/accessories/SmartSpeaker_accessory.ts
+++ b/src/accessories/SmartSpeaker_accessory.ts
@@ -1,0 +1,61 @@
+import {
+    Accessory,
+    Categories,
+    Characteristic,
+    CharacteristicEventTypes,
+    CharacteristicGetCallback, CharacteristicSetCallback, CharacteristicValue,
+    Service,
+    uuid
+} from "..";
+import {CurrentMediaState, TargetMediaState} from "../lib/gen/HomeKit-TV";
+
+const speakerUUID = uuid.generate('hap-nodejs:accessories:smart-speaker');
+const speaker = exports.accessory = new Accessory('SmartSpeaker', speakerUUID);
+
+// @ts-ignore
+speaker.username = "89:A8:E4:1E:95:EE";
+// @ts-ignore
+speaker.pincode = "676-54-344";
+speaker.category = Categories.SPEAKER;
+
+const service = new Service.SmartSpeaker('Smart Speaker', '');
+
+let currentMediaState: number = CurrentMediaState.PAUSE;
+let targetMediaState: number = TargetMediaState.PAUSE;
+
+// ConfigureName is used to listen for Name changes inside the Home App.
+// A device manufacturer would probably need to adjust the name of the device in the AirPlay 2 protocol (or something)
+service.setCharacteristic(Characteristic.ConfiguredName, "Smart Speaker");
+service.setCharacteristic(Characteristic.Mute, false);
+service.setCharacteristic(Characteristic.Volume, 100);
+
+service.getCharacteristic(Characteristic.CurrentMediaState)!
+    .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+        console.log("Reading CurrentMediaState: " + currentMediaState);
+        callback(undefined, currentMediaState);
+    }).getValue();
+
+service.getCharacteristic(Characteristic.TargetMediaState)!
+    .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+        console.log("Setting TargetMediaState to: " + value);
+        targetMediaState = value as number;
+        currentMediaState = targetMediaState;
+
+        callback();
+
+        service.setCharacteristic(Characteristic.CurrentMediaState, targetMediaState);
+    })
+    .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+        console.log("Reading TargetMediaState: " + targetMediaState);
+        callback(undefined, targetMediaState);
+    }).getValue();
+
+service.getCharacteristic(Characteristic.ConfiguredName)!
+    .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+        console.log(`Name was changed to: '${value}'`);
+        callback();
+    });
+
+speaker.addService(service);
+
+

--- a/src/lib/Service.ts
+++ b/src/lib/Service.ts
@@ -118,6 +118,7 @@ export class Service extends EventEmitter<Events> {
   static Siri: typeof HomeKitTypes.Remote.Siri;
   static Slat: typeof HomeKitTypes.Generated.Slat;
   static SmokeSensor: typeof HomeKitTypes.Generated.SmokeSensor;
+  static SmartSpeaker: typeof HomeKitTypes.Generated.SmartSpeaker;
   static Speaker: typeof HomeKitTypes.Generated.Speaker;
   static StatefulProgrammableSwitch: typeof HomeKitTypes.Bridged.StatefulProgrammableSwitch;
   static StatelessProgrammableSwitch: typeof HomeKitTypes.Generated.StatelessProgrammableSwitch;

--- a/src/lib/gen/HomeKit-TV.ts
+++ b/src/lib/gen/HomeKit-TV.ts
@@ -123,15 +123,22 @@ Characteristic.DisplayOrder = DisplayOrder;
 
 export class CurrentMediaState extends Characteristic {
 
+  static readonly PLAY = 0;
+  static readonly PAUSE = 1;
+  static readonly STOP = 2;
+  // 3 is unknown (maybe some Television specific value)
+  static readonly LOADING = 4; // seems to be SmartSpeaker specific
+  static readonly INTERRUPTED = 5; // seems to be SmartSpeaker specific
+
   static readonly UUID: string = '000000E0-0000-1000-8000-0026BB765291';
 
   constructor() {
     super('Current Media State', CurrentMediaState.UUID);
     this.setProps({
       format: Formats.UINT8,
-      maxValue: 3,
+      maxValue: 5,
       minValue: 0,
-      validValues: [0,1,2,3],
+      validValues: [0,1,2,3,4,5],
       perms: [Perms.READ, Perms.NOTIFY]
     });
     this.value = this.getDefaultValue();

--- a/src/lib/gen/HomeKit.ts
+++ b/src/lib/gen/HomeKit.ts
@@ -4320,6 +4320,31 @@ export class SmokeSensor extends Service {
 Service.SmokeSensor = SmokeSensor;
 
 /**
+ * Service "Smart Speaker"
+ */
+
+export class SmartSpeaker extends Service {
+
+  static UUID: string = '00000228-0000-1000-8000-0026BB765291';
+
+  constructor(displayName: string, subtype: string) {
+    super(displayName, SmartSpeaker.UUID, subtype);
+
+    // Required Characteristics
+    this.addCharacteristic(Characteristic.CurrentMediaState);
+    this.addCharacteristic(Characteristic.TargetMediaState);
+
+    // Optional Characteristics
+    this.addOptionalCharacteristic(Characteristic.Name);
+    this.addOptionalCharacteristic(Characteristic.ConfiguredName);
+    this.addOptionalCharacteristic(Characteristic.Volume);
+    this.addOptionalCharacteristic(Characteristic.Mute);
+  }
+}
+
+Service.SmartSpeaker = SmartSpeaker;
+
+/**
  * Service "Speaker"
  */
 


### PR DESCRIPTION
iOS 13.4 seems to have added a new SmartSpeaker service.

MediaStates kind of work in the Home App (when switching between playing and paused the loading indicator will stay though).
Volume and Mute Characteristics seem to not have any effect.

It seems a device manufacturer would need to implement AirPlay 2 additionally to have a fully working HomeKit Speaker:
![IMG_3279](https://user-images.githubusercontent.com/9783857/78010168-5b003f00-7342-11ea-9b3a-3dc1cc482a31.png)
