### PR TITLE
new HomeKit category 

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -71,7 +71,8 @@ export enum Categories {
   SHOWER_HEAD = 30,
   TELEVISION = 31,
   TARGET_CONTROLLER = 32, // Remote Control
-  ROUTER = 33 // HomeKit enabled router
+  ROUTER = 33, // HomeKit enabled router
+  AMPLIFIER = 34 //
 }
 
 export interface SerializedAccessory {


### PR DESCRIPTION
New HomeKit accessory category of 34, Amplifier, appears as icon in HomeKit pairing window under iOS 13.4