### PR TITLE
Mitigating issues with required Name characteristic

### DIFF
--- a/src/lib/Service.ts
+++ b/src/lib/Service.ts
@@ -270,14 +270,14 @@ export class Service extends EventEmitter<Events> {
     }
   }
 
-  testCharacteristic = (name: string | Characteristic) => {
+  testCharacteristic = <T extends WithUUID<typeof Characteristic>>(name: string | T) => {
     // checks for the existence of a characteristic object in the service
     var index, characteristic;
     for (index in this.characteristics) {
       characteristic = this.characteristics[index];
       if (typeof name === 'string' && characteristic.displayName === name) {
         return true;
-      } else if (typeof name === 'function' && ((characteristic instanceof name) || ((name as Characteristic).UUID === characteristic.UUID))) {
+      } else if (typeof name === 'function' && ((characteristic instanceof name) || (name.UUID === characteristic.UUID))) {
         return true;
       }
     }

--- a/src/lib/gen/HomeKit-Bridge.ts
+++ b/src/lib/gen/HomeKit-Bridge.ts
@@ -669,7 +669,9 @@ export class TunneledBTLEAccessoryService extends Service {
     super(displayName, TunneledBTLEAccessoryService.UUID, subtype);
 
     // Required Characteristics
-    this.addCharacteristic(Characteristic.Name);
+    if (!this.testCharacteristic(Characteristic.Name)) { // workaround for name characteristic collision in constructor
+      this.addCharacteristic(Characteristic.Name);
+    }
     this.addCharacteristic(Characteristic.AccessoryIdentifier);
     this.addCharacteristic(Characteristic.TunneledAccessoryStateNumber);
     this.addCharacteristic(Characteristic.TunneledAccessoryConnected);

--- a/src/lib/gen/HomeKit-TV.ts
+++ b/src/lib/gen/HomeKit-TV.ts
@@ -519,7 +519,9 @@ export class InputSource extends Service {
     this.addCharacteristic(Characteristic.ConfiguredName);
     this.addCharacteristic(Characteristic.InputSourceType);
     this.addCharacteristic(Characteristic.IsConfigured);
-    this.addCharacteristic(Characteristic.Name);
+    if (!this.testCharacteristic(Characteristic.Name)) { // workaround for name characteristic collision in constructor
+      this.addCharacteristic(Characteristic.Name).updateValue("Unnamed InputSource");
+    }
     this.addCharacteristic(Characteristic.CurrentVisibilityState);
 
     // Optional Characteristics


### PR DESCRIPTION
Mitigates regression introduced in https://github.com/KhaosT/HAP-NodeJS/pull/799 (and already discussed in https://github.com/KhaosT/HAP-NodeJS/pull/678).
See: https://github.com/KhaosT/HAP-NodeJS/blob/a3a49491c00e91ffb2a6dd4d3628e917cf61ddba/src/lib/Service.ts#L163-L165

For the long term I could imagine that we somehow alter the order in which required/optional characteristics get added and the display name gets translated into the Name characteristic.