### PR TITLE
Adding getServiceById to retrieve Service by UUID and subtype

### DIFF
--- a/src/lib/Accessory.ts
+++ b/src/lib/Accessory.ts
@@ -346,6 +346,20 @@ export class Accessory extends EventEmitter<Events> {
     }
   }
 
+  getServiceById<T extends WithUUID<typeof Service>>(uuid: string | T, subType: string): Service | undefined {
+    for (const index in this.services) {
+      const service = this.services[index];
+
+      if (typeof uuid === "string" && (service.displayName === uuid || service.name === uuid) && service.subtype === subType) {
+        return service;
+      } else if (typeof uuid === "function" && ((service instanceof uuid) || (uuid.UUID === service.UUID)) && service.subtype === subType) {
+        return service;
+      }
+    }
+
+    return undefined;
+  }
+
   /**
    * Returns the bridging accessory if this accessory is bridged.
    * Otherwise returns itself.


### PR DESCRIPTION
This basically move homebridges `getServiceByUUIDAndSubType` into hap-nodejs.

https://github.com/homebridge/homebridge/blob/e67630a3978aa126786711f8ec06610db517ca74/lib/platformAccessory.js#L113-L122